### PR TITLE
feat: implement multiple configs with aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,6 @@
 
 A generic CLI tool to sync [Cursor editor](https://cursor.sh) `.cursor/` folder contents (rules, commands, docs, and more) from **your own** GitHub repository to any project. This tool does **not** include any cursor rules - you must configure your own repository containing your `.cursor` folder. Perfect for teams and individuals who want to maintain consistent coding standards and AI assistant configurations across multiple projects.
 
-## Features
-
-- 🔄 **Sync** `.cursor/` folder contents from repository to any project
-- 📤 **Push** local changes back to the repository
-- 📊 **Status** check to see what's different
-- 🔍 **Diff** view for individual files
-- ⚙️ **Configuration** management via config files
-- 🛡️ **Auto-preserve** project-specific files
-- 🚀 **Dry-run** mode to preview changes
-- 📝 **Verbose** output for debugging
-
 ## Installation
 
 ### Via npm (Recommended)
@@ -63,6 +52,49 @@ npm install -g git+https://github.com/eyyMinda/CRules-CLI.git
    crules push
    ```
 
+## Quick Examples
+
+**First time setup:**
+
+```bash
+# 1. Configure your cursor rules repository (required)
+crules config set repository https://github.com/username/your-cursor-rules.git
+
+# 2. Sync rules to your project
+crules sync
+```
+
+**Daily usage:**
+
+```bash
+# Get latest rules from repository
+crules sync
+
+# Check what changed
+crules status
+
+# Push your changes back
+crules push
+
+# View diff for a specific file
+crules diff rules/some-rule.mdc
+```
+
+**Multiple configs (for different project types):**
+
+```bash
+# Create configs for different project types
+crules config create shopify-theme --repository https://github.com/user/shopify-rules.git
+crules config create react --repository https://github.com/user/react-rules.git
+
+# Switch between configs
+crules config use shopify-theme
+crules sync  # Uses shopify-theme config
+
+crules config use react
+crules sync  # Uses react config
+```
+
 ## Commands
 
 ### `crules sync`
@@ -78,11 +110,21 @@ crules sync [options]
 - `-v, --verbose` - Show detailed output
 - `--dry-run` - Preview changes without applying them
 
+**Examples:**
+
+```bash
+crules sync
+crules sync --verbose
+crules sync --dry-run  # Preview what would change
+```
+
 **What it does:**
 
 - Updates the cached repository
 - Copies `.cursor` folder to your project
 - Preserves project-specific files (files matching the configured pattern)
+
+---
 
 ### `crules push`
 
@@ -98,12 +140,23 @@ crules push [options]
 - `--dry-run` - Preview what would be pushed
 - `-f, --force` - Skip confirmation prompts
 
+**Examples:**
+
+```bash
+crules push
+crules push --verbose
+crules push --dry-run  # See what would be pushed
+crules push --force    # Skip confirmation
+```
+
 **What it does:**
 
 - Shows what files were added/modified/deleted
 - Optionally shows detailed diff
 - Prompts for confirmation (unless `--force`)
 - Commits and pushes changes to GitHub
+
+---
 
 ### `crules status`
 
@@ -117,12 +170,21 @@ crules status [options]
 
 - `-v, --verbose` - Show detailed output
 
+**Examples:**
+
+```bash
+crules status
+crules status --verbose
+```
+
 **What it shows:**
 
 - New files (not in repo)
 - Modified files (different from repo)
 - Deleted files (in repo but not in project)
 - Synced files count
+
+---
 
 ### `crules diff <file>`
 
@@ -136,45 +198,115 @@ crules diff <file-path> [options]
 
 - `-v, --verbose` - Show unchanged lines
 
-**Example:**
+**Examples:**
 
 ```bash
 crules diff rules/shopify-reusable-snippets.mdc
+crules diff commands/generate-component.mdc --verbose
 ```
+
+---
 
 ### `crules config`
 
-Manage configuration settings.
+Manage configuration settings and multiple config profiles.
 
 ```bash
-crules config [get|set] [key] [value] [options]
+crules config <action> [arguments] [options]
 ```
+
+**Actions:**
+
+- `list` - List all available configs
+- `get [key]` - Get active config (or specific key)
+- `set <key> <value>` - Set value in active config
+- `use <alias>` - Switch to a named config
+- `create <alias>` - Create a new named config
+- `edit <alias> <key> <value>` - Edit a specific config value
+- `rename <old-alias> <new-alias>` - Rename a config alias
+- `delete <alias>` - Delete a config
 
 **Options:**
 
 - `-g, --global` - Use global config file (`~/.cursor-rules.json`)
+- `-a, --alias <alias>` - Specify config alias for get/set operations
+- `-r, --repository <url>` - Repository URL (for create command)
+- `-p, --pattern <pattern>` - Project-specific pattern (for create command)
+- `-m, --commit-message <message>` - Commit message template (for create command)
 
 **Examples:**
 
 ```bash
-# Show all configuration
+# List all configs
+crules config list
+
+# Show active configuration
 crules config get
 
 # Get specific value
 crules config get repository
 
-# Set a value (local config)
+# Set repository URL
 crules config set repository https://github.com/user/repo.git
-
-# Set a value (global config)
 crules config set repository https://github.com/user/repo.git --global
+
+# Create and use a new config
+crules config create shopify-theme --repository https://github.com/user/shopify-rules.git
+crules config use shopify-theme
+
+# Edit a config value
+crules config edit shopify-theme repository https://github.com/user/new-repo.git
+
+# Rename a config
+crules config rename shopify-theme shopify-app
+
+# Delete a config
+crules config delete shopify-theme
 ```
+
+## Features
+
+- 🔄 **Sync** `.cursor/` folder contents from repository to any project
+- 📤 **Push** local changes back to the repository
+- 📊 **Status** check to see what's different
+- 🔍 **Diff** view for individual files
+- ⚙️ **Multiple configs** - Switch between different cursor rules repositories
+- 🛡️ **Auto-preserve** project-specific files
+- 🚀 **Dry-run** mode to preview changes
+- 📝 **Verbose** output for debugging
 
 ## Configuration
 
 **🔴 Required:** You **must** configure a repository URL before using this tool. The CLI will not work without a configured repository.
 
+CRules CLI supports **multiple named configs**, allowing you to switch between different cursor rules repositories for different project types (e.g., React development, Shopify themes, Shopify apps).
+
 Configuration can be set globally (`~/.cursor-rules.json`) or per-project (`.cursor-rules.json` in project root). Local config overrides global config.
+
+### Multiple Configs
+
+You can create multiple config profiles with aliases to manage different cursor rules repositories:
+
+- **Default config**: No alias required, always available
+- **Named configs**: Must have an alias (e.g., `shopify-theme`, `react`, `shopify-app`)
+- **Active config**: The currently selected config used by sync/push/status/diff commands
+- **Cache isolation**: Each config has its own cache directory
+
+**Example workflow:**
+
+```bash
+# Create configs for different project types
+crules config create shopify-theme --repository https://github.com/user/shopify-theme-rules.git
+crules config create react --repository https://github.com/user/react-rules.git
+crules config create shopify-app --repository https://github.com/user/shopify-app-rules.git
+
+# Switch between configs
+crules config use shopify-theme  # Now sync/push will use shopify-theme config
+crules config use react           # Switch to react config
+
+# List all configs
+crules config list
+```
 
 ### Setting Up Your Repository
 
@@ -191,8 +323,14 @@ Configuration can be set globally (`~/.cursor-rules.json`) or per-project (`.cur
            └── your-docs.md
    ```
 3. Configure the repository URL:
+
    ```bash
+   # For default config
    crules config set repository https://github.com/username/your-cursor-rules.git
+
+   # Or create a named config
+   crules config create my-config --repository https://github.com/username/your-cursor-rules.git
+   crules config use my-config
    ```
 
 ### Supported .cursor/ Folder Types
@@ -224,19 +362,49 @@ CRules CLI supports syncing all folders within the `.cursor/` directory. The fol
 
 ### Configuration Options
 
+**New Multi-Config Format:**
+
 ```json
 {
-  "repository": "https://github.com/username/cursor-rules.git",
-  "cacheDir": "~/.cursor-rules-cache",
-  "projectSpecificPattern": "^project-",
-  "commitMessage": "Update cursor rules: {summary}"
+  "active": "shopify-theme",
+  "configs": {
+    "default": {
+      "repository": "https://github.com/username/cursor-rules.git",
+      "cacheDir": "~/.cursor-rules-cache/default",
+      "projectSpecificPattern": "^project-",
+      "commitMessage": "Update cursor rules: {summary}"
+    },
+    "shopify-theme": {
+      "repository": "https://github.com/username/shopify-theme-rules.git",
+      "cacheDir": "~/.cursor-rules-cache/shopify-theme",
+      "projectSpecificPattern": "^project-",
+      "commitMessage": "Update cursor rules: {summary}"
+    },
+    "react": {
+      "repository": "https://github.com/username/react-rules.git",
+      "cacheDir": "~/.cursor-rules-cache/react",
+      "projectSpecificPattern": "^project-",
+      "commitMessage": "Update cursor rules: {summary}"
+    }
+  }
 }
 ```
 
+**Config Properties:**
+
+- **active**: Name of the currently active config (defaults to "default")
+- **configs**: Object containing all config profiles
+  - **default**: The default config (no alias, always exists)
+  - **[alias]**: Named configs with aliases (e.g., "shopify-theme", "react")
+
+**Per-Config Options:**
+
 - **repository** (required): Git repository URL containing your `.cursor` folder. Must be configured before using any commands.
-- **cacheDir**: Local directory to cache the repository (supports `~` expansion)
+- **cacheDir**: Local directory to cache the repository (supports `~` expansion). Named configs automatically use `~/.cursor-rules-cache/{alias}` unless customized.
 - **projectSpecificPattern**: Regex pattern to identify project-specific files
 - **commitMessage**: Commit message template (use `{summary}` placeholder)
+
+**Note:** Old single-config format is automatically migrated to the new multi-config format on first use.
 
 ### Project-Specific Files
 
@@ -281,10 +449,22 @@ crules sync
 ### Setting up a new project:
 
 ```bash
+# Option 1: Use default config
 # 1. Configure repository (required - no default repository)
 crules config set repository https://github.com/your-org/cursor-rules.git
 
 # 2. Sync rules
+crules sync
+
+# Option 2: Use a named config
+# 1. Switch to existing config (if you have one)
+crules config use shopify-theme
+
+# 2. Or create a new config for this project type
+crules config create shopify-theme --repository https://github.com/your-org/shopify-rules.git
+crules config use shopify-theme
+
+# 3. Sync rules
 crules sync
 ```
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,8 +1,23 @@
-const { getConfig, getConfigValue, setConfigValue, getConfigPath, DEFAULT_CONFIG } = require('../config');
+const {
+  getAllConfigs,
+  getActiveConfigName,
+  getActiveConfig,
+  getConfig,
+  setActiveConfig,
+  createConfig,
+  deleteConfig,
+  renameConfig,
+  updateConfig,
+  getConfigValue,
+  setConfigValue,
+  isValidAlias,
+  DEFAULT_CONFIG
+} = require('../config');
 const { promptUser } = require('../utils');
 
-function displayConfig(config) {
-  console.log('\n📋 Current Configuration:\n');
+function displayConfig(config, alias = null) {
+  const aliasLabel = alias ? ` (${alias})` : '';
+  console.log(`\n📋 Configuration${aliasLabel}:\n`);
   for (const [key, value] of Object.entries(config)) {
     console.log(`  ${key}: ${value}`);
   }
@@ -13,16 +28,39 @@ function displayConfigValue(key, value) {
   console.log(`\n${key}: ${value}\n`);
 }
 
+function displayConfigList(configs, activeName) {
+  console.log('\n📋 Available Configs:\n');
+  for (const [alias, config] of Object.entries(configs)) {
+    const activeMarker = alias === activeName ? ' (active)' : '';
+    const repo = config.repository || '(not configured)';
+    console.log(`  ${alias}${activeMarker}`);
+    console.log(`    Repository: ${repo}`);
+    console.log(`    Cache Dir: ${config.cacheDir || 'default'}`);
+    console.log('');
+  }
+}
+
+async function configListCommand(options) {
+  const allConfigs = getAllConfigs();
+  const activeName = getActiveConfigName();
+  displayConfigList(allConfigs.configs, activeName);
+  console.log(`⚙️  Active config: ${activeName}`);
+  console.log(`⚙️  Switch configs using: crules config use <alias>`);
+}
+
 async function configGetCommand(key, options) {
+  const alias = options.alias || null;
+
   if (!key) {
-    const config = getConfig();
-    displayConfig(config);
-    console.log(`💡 Use 'crules config get <key>' to get a specific value`);
-    console.log(`💡 Use 'crules config set <key> <value>' to set a value`);
+    const config = getConfig(alias);
+    const displayAlias = alias || getActiveConfigName();
+    displayConfig(config, displayAlias);
+    console.log(`⚙️  Use 'crules config get <key>' to get a specific value`);
+    console.log(`⚙️  Use 'crules config set <key> <value>' to set a value`);
     return;
   }
 
-  const value = getConfigValue(key);
+  const value = getConfigValue(key, alias);
   if (value === undefined) {
     console.error(`\n❌ Configuration key '${key}' not found`);
     console.log(`\nAvailable keys: ${Object.keys(DEFAULT_CONFIG).join(', ')}`);
@@ -49,30 +87,222 @@ async function configSetCommand(key, value, options) {
   }
 
   const global = options.global || false;
+  const alias = options.alias || null;
 
   try {
-    setConfigValue(key, value, global);
+    setConfigValue(key, value, global, alias);
     const location = global ? 'global' : 'local';
-    console.log(`\n✅ Set ${key} = ${value} (${location} config)`);
+    const configLabel = alias ? `config '${alias}'` : 'active config';
+    console.log(`\n✅ Set ${key} = ${value} (${configLabel}, ${location})`);
   } catch (error) {
     console.error(`\n❌ Failed to set config: ${error.message}`);
   }
 }
 
+async function configUseCommand(alias, options) {
+  if (!alias) {
+    console.error('\n❌ Alias is required');
+    console.log('Usage: crules config use <alias>');
+    return;
+  }
+
+  const global = options.global || false;
+
+  try {
+    setActiveConfig(alias, global);
+    const location = global ? 'global' : 'local';
+    console.log(`\n✅ Switched to config '${alias}' (${location})`);
+
+    const config = getConfig(alias);
+    const repo = config.repository || '(not configured)';
+    console.log(`   Repository: ${repo}`);
+  } catch (error) {
+    console.error(`\n❌ Failed to switch config: ${error.message}`);
+  }
+}
+
+async function configCreateCommand(alias, options) {
+  if (!alias) {
+    console.error('\n❌ Alias is required');
+    console.log('Usage: crules config create <alias>');
+    console.log('Example: crules config create shopify-theme');
+    return;
+  }
+
+  if (!isValidAlias(alias)) {
+    console.error('\n❌ Invalid alias');
+    console.log('Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    return;
+  }
+
+  const global = options.global || false;
+
+  try {
+    // Prompt for repository if not provided
+    let repository = options.repository || null;
+    if (!repository) {
+      repository = await promptUser('Enter repository URL (or press Enter to skip): ');
+      if (!repository || repository.trim() === '') {
+        repository = '';
+      }
+    }
+
+    const configData = {
+      repository: repository,
+      projectSpecificPattern: options.pattern || '^project-',
+      commitMessage: options.commitMessage || 'Update cursor rules: {summary}'
+    };
+
+    createConfig(alias, configData, global);
+    const location = global ? 'global' : 'local';
+    console.log(`\n✅ Created config '${alias}' (${location})`);
+
+    if (repository) {
+      console.log(`   Repository: ${repository}`);
+    } else {
+      console.log(`   ⚙️  Configure repository using: crules config edit ${alias} repository <url>`);
+    }
+  } catch (error) {
+    console.error(`\n❌ Failed to create config: ${error.message}`);
+  }
+}
+
+async function configDeleteCommand(alias, options) {
+  if (!alias) {
+    console.error('\n❌ Alias is required');
+    console.log('Usage: crules config delete <alias>');
+    return;
+  }
+
+  if (alias === 'default') {
+    console.error('\n❌ Cannot delete "default" config');
+    return;
+  }
+
+  const global = options.global || false;
+
+  try {
+    const confirm = await promptUser(`Are you sure you want to delete config '${alias}'? (y/n): `);
+    if (confirm !== 'y' && confirm !== 'yes') {
+      console.log('\n❌ Delete cancelled.');
+      return;
+    }
+
+    deleteConfig(alias, global);
+    const location = global ? 'global' : 'local';
+    console.log(`\n✅ Deleted config '${alias}' (${location})`);
+  } catch (error) {
+    console.error(`\n❌ Failed to delete config: ${error.message}`);
+  }
+}
+
+async function configEditCommand(alias, key, value, options) {
+  if (!alias) {
+    console.error('\n❌ Alias is required');
+    console.log('Usage: crules config edit <alias> <key> <value>');
+    console.log('   Or: crules config edit <alias> --key <key> --value <value>');
+    console.log(`Available keys: ${Object.keys(DEFAULT_CONFIG).join(', ')}`);
+    return;
+  }
+
+  // Support both formats: edit alias key value OR edit alias --key key --value value
+  const configKey = options.key || key;
+  const configValue = options.editValue || options.value || value;
+
+  if (!configKey) {
+    console.error('\n❌ Key is required');
+    console.log('Usage: crules config edit <alias> <key> <value>');
+    console.log('   Or: crules config edit <alias> --key <key> --value <value>');
+    console.log(`Available keys: ${Object.keys(DEFAULT_CONFIG).join(', ')}`);
+    return;
+  }
+
+  let finalValue = configValue;
+  if (!finalValue) {
+    finalValue = await promptUser(`Enter value for '${configKey}': `);
+    if (!finalValue) {
+      console.error('\n❌ Value is required');
+      return;
+    }
+  }
+
+  const global = options.global || false;
+
+  try {
+    updateConfig(alias, configKey, finalValue, global);
+    const location = global ? 'global' : 'local';
+    console.log(`\n✅ Updated ${configKey} = ${finalValue} in config '${alias}' (${location})`);
+  } catch (error) {
+    console.error(`\n❌ Failed to update config: ${error.message}`);
+  }
+}
+
+async function configRenameCommand(oldAlias, newAlias, options) {
+  if (!oldAlias) {
+    console.error('\n❌ Old alias is required');
+    console.log('Usage: crules config rename <old-alias> <new-alias>');
+    return;
+  }
+
+  if (!newAlias) {
+    console.error('\n❌ New alias is required');
+    console.log('Usage: crules config rename <old-alias> <new-alias>');
+    return;
+  }
+
+  if (oldAlias === 'default') {
+    console.error('\n❌ Cannot rename "default" config');
+    return;
+  }
+
+  if (!isValidAlias(newAlias)) {
+    console.error('\n❌ Invalid new alias');
+    console.log('Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    return;
+  }
+
+  const global = options.global || false;
+
+  try {
+    renameConfig(oldAlias, newAlias, global);
+    const location = global ? 'global' : 'local';
+    console.log(`\n✅ Renamed config '${oldAlias}' to '${newAlias}' (${location})`);
+  } catch (error) {
+    console.error(`\n❌ Failed to rename config: ${error.message}`);
+  }
+}
+
 async function configCommand(action, key, value, options) {
   try {
-    if (action === 'get') {
+    if (action === 'list') {
+      await configListCommand(options);
+    } else if (action === 'get') {
       await configGetCommand(key, options);
     } else if (action === 'set') {
       await configSetCommand(key, value, options);
+    } else if (action === 'use') {
+      await configUseCommand(key, options); // key is alias here
+    } else if (action === 'create') {
+      await configCreateCommand(key, options); // key is alias here
+    } else if (action === 'delete') {
+      await configDeleteCommand(key, options); // key is alias here
+    } else if (action === 'edit') {
+      await configEditCommand(key, value, options); // key is alias, value is config key
+    } else if (action === 'rename') {
+      await configRenameCommand(key, value, options); // key is old alias, value is new alias
     } else {
       console.error(`\n❌ Unknown action: ${action}`);
-      console.log('Available actions: get, set');
+      console.log('Available actions: list, get, set, use, create, delete, edit, rename');
       console.log('\nExamples:');
+      console.log('  crules config list');
       console.log('  crules config get');
       console.log('  crules config get repository');
       console.log('  crules config set repository https://github.com/user/repo.git');
-      console.log('  crules config set repository https://github.com/user/repo.git --global');
+      console.log('  crules config use shopify-theme');
+      console.log('  crules config create shopify-theme');
+      console.log('  crules config edit shopify-theme repository https://github.com/user/repo.git');
+      console.log('  crules config rename shopify-theme shopify-app');
+      console.log('  crules config delete shopify-theme');
     }
   } catch (error) {
     console.error(`\n❌ Error: ${error.message}`);

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -14,7 +14,7 @@ const {
   ensureDir,
   getCacheDir
 } = require('../utils');
-const { getConfig } = require('../config');
+const { getActiveConfig } = require('../config');
 
 async function compareFiles() {
   const cursorDir = getCursorDir();
@@ -200,10 +200,10 @@ async function pushChanges(changes, options) {
   console.log('\n📤 Committing changes...');
   await execAsync('git add .cursor/', { cwd: cacheDir });
 
-  const config = getConfig();
+  const config = getActiveConfig();
   const summary = `${changes.added.length} added, ${changes.modified.length} modified, ${changes.deleted.length} deleted`;
   const commitMessage = config.commitMessage.replace('{summary}', summary);
-  
+
   await execAsync(`git commit -m "${commitMessage}"`, { cwd: cacheDir });
 
   console.log('📤 Pushing to repository...');

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,7 @@ const CONFIG_FILE_NAME = '.cursor-rules.json';
 const GLOBAL_CONFIG_PATH = path.join(os.homedir(), CONFIG_FILE_NAME);
 const LOCAL_CONFIG_PATH = path.join(process.cwd(), CONFIG_FILE_NAME);
 
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG_VALUES = {
   repository: '',
   cacheDir: path.join(os.homedir(), '.cursor-rules-cache'),
   projectSpecificPattern: '^project-',
@@ -21,80 +21,326 @@ function pathExists(filePath) {
   }
 }
 
-function loadConfig() {
-  let config = { ...DEFAULT_CONFIG };
+function isValidAlias(alias) {
+  // Alias must be alphanumeric with hyphens and underscores, not starting with number
+  return /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(alias);
+}
+
+function isOldConfigFormat(config) {
+  // Old format has repository, cacheDir, etc. at root level
+  // New format has active and configs properties
+  return config && !config.configs && (config.repository !== undefined || config.cacheDir !== undefined);
+}
+
+function migrateOldConfig(oldConfig) {
+  const migrated = {
+    active: 'default',
+    configs: {
+      default: {
+        repository: oldConfig.repository || DEFAULT_CONFIG_VALUES.repository,
+        cacheDir: oldConfig.cacheDir || DEFAULT_CONFIG_VALUES.cacheDir,
+        projectSpecificPattern: oldConfig.projectSpecificPattern || DEFAULT_CONFIG_VALUES.projectSpecificPattern,
+        commitMessage: oldConfig.commitMessage || DEFAULT_CONFIG_VALUES.commitMessage
+      }
+    }
+  };
+
+  // Expand ~ in paths
+  if (migrated.configs.default.cacheDir && migrated.configs.default.cacheDir.startsWith('~')) {
+    migrated.configs.default.cacheDir = migrated.configs.default.cacheDir.replace('~', os.homedir());
+  }
+
+  return migrated;
+}
+
+function loadConfigFile(configPath) {
+  if (!pathExists(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(content);
+
+    // Migrate old format if detected
+    if (isOldConfigFormat(config)) {
+      return migrateOldConfig(config);
+    }
+
+    return config;
+  } catch (error) {
+    console.warn(`⚠️  Warning: Could not parse config at ${configPath}: ${error.message}`);
+    return null;
+  }
+}
+
+function loadAllConfigs() {
+  // Start with default structure
+  let configData = {
+    active: 'default',
+    configs: {
+      default: { ...DEFAULT_CONFIG_VALUES }
+    }
+  };
 
   // Load global config first
-  if (pathExists(GLOBAL_CONFIG_PATH)) {
-    try {
-      const globalConfig = JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf8'));
-      config = { ...config, ...globalConfig };
-    } catch (error) {
-      console.warn(`⚠️  Warning: Could not parse global config: ${error.message}`);
+  const globalConfig = loadConfigFile(GLOBAL_CONFIG_PATH);
+  if (globalConfig) {
+    configData = { ...configData, ...globalConfig };
+    // Merge configs object
+    if (globalConfig.configs) {
+      configData.configs = { ...configData.configs, ...globalConfig.configs };
     }
   }
 
   // Load local config (overrides global)
-  if (pathExists(LOCAL_CONFIG_PATH)) {
-    try {
-      const localConfig = JSON.parse(fs.readFileSync(LOCAL_CONFIG_PATH, 'utf8'));
-      config = { ...config, ...localConfig };
-    } catch (error) {
-      console.warn(`⚠️  Warning: Could not parse local config: ${error.message}`);
+  const localConfig = loadConfigFile(LOCAL_CONFIG_PATH);
+  if (localConfig) {
+    // Local active config overrides global
+    if (localConfig.active !== undefined) {
+      configData.active = localConfig.active;
+    }
+    // Merge configs object
+    if (localConfig.configs) {
+      configData.configs = { ...configData.configs, ...localConfig.configs };
     }
   }
 
-  // Expand ~ in paths
-  if (config.cacheDir && config.cacheDir.startsWith('~')) {
-    config.cacheDir = config.cacheDir.replace('~', os.homedir());
+  // Ensure default config exists
+  if (!configData.configs.default) {
+    configData.configs.default = { ...DEFAULT_CONFIG_VALUES };
   }
 
-  return config;
-}
-
-function getConfig() {
-  return loadConfig();
-}
-
-function getConfigValue(key) {
-  const config = loadConfig();
-  return config[key];
-}
-
-function setConfigValue(key, value, global = false) {
-  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
-  let config = {};
-
-  if (pathExists(configPath)) {
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    } catch {
-      config = {};
+  // Expand ~ in paths for all configs and set per-config cache dirs
+  for (const alias in configData.configs) {
+    const config = configData.configs[alias];
+    if (config.cacheDir && config.cacheDir.startsWith('~')) {
+      config.cacheDir = config.cacheDir.replace('~', os.homedir());
+    }
+    // Set default cacheDir pattern for non-default configs if not customized
+    if (alias !== 'default') {
+      const baseCacheDir = configData.configs.default.cacheDir || DEFAULT_CONFIG_VALUES.cacheDir;
+      if (!config.cacheDir || config.cacheDir === baseCacheDir) {
+        // Only set default pattern if cacheDir is empty or matches base (not customized)
+        config.cacheDir = path.join(baseCacheDir, alias);
+      }
     }
   }
 
-  config[key] = value;
+  return configData;
+}
 
+function saveConfigFile(configPath, configData) {
   try {
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(configPath, JSON.stringify(configData, null, 2) + '\n', 'utf8');
     return true;
   } catch (error) {
     throw new Error(`Failed to write config: ${error.message}`);
   }
 }
 
+function getAllConfigs() {
+  return loadAllConfigs();
+}
+
+function getActiveConfigName() {
+  const configData = loadAllConfigs();
+  return configData.active || 'default';
+}
+
+function getActiveConfig() {
+  const configData = loadAllConfigs();
+  const activeName = configData.active || 'default';
+  return configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES };
+}
+
+function getConfig(alias) {
+  const configData = loadAllConfigs();
+  if (alias) {
+    return configData.configs[alias] || null;
+  }
+  return getActiveConfig();
+}
+
+function setActiveConfig(alias, global = false) {
+  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
+  const configData = loadConfigFile(configPath) || { configs: {} };
+
+  // Validate alias exists
+  const allConfigs = loadAllConfigs();
+  if (!allConfigs.configs[alias]) {
+    throw new Error(`Config '${alias}' does not exist`);
+  }
+
+  configData.active = alias;
+  if (!configData.configs) {
+    configData.configs = {};
+  }
+
+  return saveConfigFile(configPath, configData);
+}
+
+function createConfig(alias, configData = null, global = false) {
+  if (!alias || alias === 'default') {
+    throw new Error('Cannot create config with alias "default". Use "default" config or create a named config.');
+  }
+
+  if (!isValidAlias(alias)) {
+    throw new Error('Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+  }
+
+  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
+  const allConfigs = loadAllConfigs();
+
+  if (allConfigs.configs[alias]) {
+    throw new Error(`Config '${alias}' already exists`);
+  }
+
+  const newConfig = configData || { ...DEFAULT_CONFIG_VALUES };
+
+  // Set cacheDir with alias if not provided
+  if (!newConfig.cacheDir) {
+    const baseCacheDir = allConfigs.configs.default?.cacheDir || DEFAULT_CONFIG_VALUES.cacheDir;
+    newConfig.cacheDir = path.join(baseCacheDir, alias);
+  }
+
+  // Expand ~ in paths
+  if (newConfig.cacheDir && newConfig.cacheDir.startsWith('~')) {
+    newConfig.cacheDir = newConfig.cacheDir.replace('~', os.homedir());
+  }
+
+  const fileConfig = loadConfigFile(configPath) || { configs: {} };
+  if (!fileConfig.configs) {
+    fileConfig.configs = {};
+  }
+  fileConfig.configs[alias] = newConfig;
+
+  return saveConfigFile(configPath, fileConfig);
+}
+
+function deleteConfig(alias, global = false) {
+  if (alias === 'default') {
+    throw new Error('Cannot delete "default" config');
+  }
+
+  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
+  const allConfigs = loadAllConfigs();
+
+  if (!allConfigs.configs[alias]) {
+    throw new Error(`Config '${alias}' does not exist`);
+  }
+
+  if (allConfigs.active === alias) {
+    throw new Error(`Cannot delete active config '${alias}'. Switch to another config first using 'crules config use <alias>'.`);
+  }
+
+  const fileConfig = loadConfigFile(configPath) || { configs: {} };
+  if (!fileConfig.configs) {
+    fileConfig.configs = {};
+  }
+
+  delete fileConfig.configs[alias];
+
+  return saveConfigFile(configPath, fileConfig);
+}
+
+function renameConfig(oldAlias, newAlias, global = false) {
+  if (oldAlias === 'default') {
+    throw new Error('Cannot rename "default" config');
+  }
+
+  if (!isValidAlias(newAlias)) {
+    throw new Error('Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+  }
+
+  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
+  const allConfigs = loadAllConfigs();
+
+  if (!allConfigs.configs[oldAlias]) {
+    throw new Error(`Config '${oldAlias}' does not exist`);
+  }
+
+  if (allConfigs.configs[newAlias]) {
+    throw new Error(`Config '${newAlias}' already exists`);
+  }
+
+  const fileConfig = loadConfigFile(configPath) || { configs: {} };
+  if (!fileConfig.configs) {
+    fileConfig.configs = {};
+  }
+
+  // Copy config to new alias
+  fileConfig.configs[newAlias] = { ...fileConfig.configs[oldAlias] };
+
+  // Update cacheDir if it contains the old alias
+  if (fileConfig.configs[newAlias].cacheDir) {
+    const baseCacheDir = allConfigs.configs.default?.cacheDir || DEFAULT_CONFIG_VALUES.cacheDir;
+    fileConfig.configs[newAlias].cacheDir = path.join(baseCacheDir, newAlias);
+  }
+
+  // Delete old alias
+  delete fileConfig.configs[oldAlias];
+
+  // Update active if it was the old alias
+  if (fileConfig.active === oldAlias) {
+    fileConfig.active = newAlias;
+  }
+
+  return saveConfigFile(configPath, fileConfig);
+}
+
+function updateConfig(alias, key, value, global = false) {
+  const configPath = global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
+  const allConfigs = loadAllConfigs();
+  const targetAlias = alias || allConfigs.active || 'default';
+
+  if (!allConfigs.configs[targetAlias]) {
+    throw new Error(`Config '${targetAlias}' does not exist`);
+  }
+
+  const fileConfig = loadConfigFile(configPath) || { configs: {} };
+  if (!fileConfig.configs) {
+    fileConfig.configs = {};
+  }
+
+  if (!fileConfig.configs[targetAlias]) {
+    // Copy from all configs if not in this file
+    fileConfig.configs[targetAlias] = { ...allConfigs.configs[targetAlias] };
+  }
+
+  fileConfig.configs[targetAlias][key] = value;
+
+  // Expand ~ in paths
+  if (key === 'cacheDir' && value && value.startsWith('~')) {
+    fileConfig.configs[targetAlias][key] = value.replace('~', os.homedir());
+  }
+
+  return saveConfigFile(configPath, fileConfig);
+}
+
+function getConfigValue(key, alias = null) {
+  const config = getConfig(alias);
+  return config ? config[key] : undefined;
+}
+
+function setConfigValue(key, value, global = false, alias = null) {
+  return updateConfig(alias, key, value, global);
+}
+
 function getConfigPath(global = false) {
   return global ? GLOBAL_CONFIG_PATH : LOCAL_CONFIG_PATH;
 }
 
-function validateRepository() {
-  const config = loadConfig();
-  const repo = config.repository;
+function validateRepository(alias = null) {
+  const config = getConfig(alias);
+  const repo = config ? config.repository : '';
 
   if (!repo || repo.trim() === '') {
+    const activeName = alias || getActiveConfigName();
     throw new Error(
-      'Repository not configured. Please set it using:\n' +
-      '  crules config set repository <your-repo-url>\n\n' +
+      `Repository not configured for config '${activeName}'. Please set it using:\n` +
+      `  crules config set repository <your-repo-url>\n` +
+      `  crules config edit ${activeName} repository <your-repo-url>\n\n` +
       'Example:\n' +
       '  crules config set repository https://github.com/username/cursor-rules.git\n' +
       '  crules config set repository https://github.com/username/cursor-rules.git --global'
@@ -104,12 +350,32 @@ function validateRepository() {
   return repo;
 }
 
+// Legacy compatibility functions
+function loadConfig() {
+  return getActiveConfig();
+}
+
 module.exports = {
+  // New multi-config API
+  getAllConfigs,
+  getActiveConfigName,
+  getActiveConfig,
   getConfig,
+  setActiveConfig,
+  createConfig,
+  deleteConfig,
+  renameConfig,
+  updateConfig,
   getConfigValue,
   setConfigValue,
   getConfigPath,
   validateRepository,
-  DEFAULT_CONFIG,
+  isValidAlias,
+
+  // Legacy API (for backward compatibility)
+  loadConfig,
+
+  // Constants
+  DEFAULT_CONFIG: DEFAULT_CONFIG_VALUES,
   CONFIG_FILE_NAME
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,16 +5,16 @@ const { exec } = require('child_process');
 const { promisify } = require('util');
 const os = require('os');
 const readline = require('readline');
-const { getConfig, validateRepository } = require('./config');
+const { getActiveConfig, validateRepository } = require('./config');
 
 const execAsync = promisify(exec);
 
 function getRepoUrl() {
-  return getConfig().repository;
+  return getActiveConfig().repository;
 }
 
 function getCacheDir() {
-  return getConfig().cacheDir;
+  return getActiveConfig().cacheDir;
 }
 
 function getCursorSourceDir() {
@@ -22,7 +22,7 @@ function getCursorSourceDir() {
 }
 
 function getProjectSpecificPattern() {
-  const pattern = getConfig().projectSpecificPattern;
+  const pattern = getActiveConfig().projectSpecificPattern;
   try {
     return new RegExp(pattern);
   } catch (error) {


### PR DESCRIPTION
- Add support for multiple named configs (e.g., shopify-theme, react)
- Implement config commands: create, use, delete, edit, rename, list
- Maintain backward compatibility with simple 3-step workflow
- Auto-migrate old single config format to new multi-config format
- Add per-config cache directory isolation
- Update README with multi-config documentation
- Replace light bulb icons with gear icons in config commands

Resolves #1