### PR TITLE
fix(tui): deduplicate errors + refactor unused code

### DIFF
--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -12,6 +12,7 @@ const {
   execAsync,
   getCursorSourceDir,
   getProjectSpecificFiles,
+  getProjectSpecificPattern,
   ensureDir,
   getCacheDir,
   ensureGitIdentity,
@@ -37,7 +38,6 @@ async function compareFiles() {
     unchanged: []
   };
 
-  const { getProjectSpecificPattern } = require('../utils');
   const pattern = getProjectSpecificPattern();
 
   for (const [relPath, projectPath] of Object.entries(projectFiles)) {

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -7,6 +7,7 @@ const {
   getFileHash,
   getCursorSourceDir,
   getProjectSpecificFiles,
+  getProjectSpecificPattern,
   filterFilesByIgnore,
   getRemoteDiffPaths,
   getCacheDir,
@@ -30,7 +31,6 @@ async function getStatus() {
     synced: []
   };
 
-  const { getProjectSpecificPattern } = require('../utils');
   const pattern = getProjectSpecificPattern();
 
   for (const [relPath, projectPath] of Object.entries(projectFiles)) {

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -129,7 +129,6 @@ async function syncCommand(options) {
 
   } catch (error) {
     loader?.fail(error.message);
-    console.error('\n❌ Error syncing Cursor Rules:', error.message);
     if (error.suggestions) {
       error.suggestions.forEach(suggestion => console.log(`   💡 ${suggestion}`));
     }

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -4,9 +4,9 @@ const {
   getCursorDir,
   ensureCache,
   getProjectSpecificFiles,
+  getProjectSpecificPattern,
   pathExists,
   ensureDir,
-  getCursorSourceDir,
   getIgnoreList,
   isPathIgnored,
   createOutput,
@@ -110,7 +110,6 @@ async function syncCommand(options) {
     }
 
     if (verbose && loader) loader.text = 'Copying cursor files...';
-    const { getProjectSpecificPattern } = require('../utils');
     const pattern = getProjectSpecificPattern();
     await copyDir(sourceCursorDir, cursorDir, pattern, sourceCursorDir);
 

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -128,8 +128,7 @@ async function runTUI() {
   try {
     await runAction(choice);
   } catch (err) {
-    console.error('\n❌', err.message);
-    process.exit(1);
+    // Error already displayed by command (loader.fail + suggestions)
   }
 
   // Loop back to menu

--- a/lib/config.js
+++ b/lib/config.js
@@ -235,10 +235,6 @@ function setConfigValue(key, value, local = false, alias = null) {
   return updateConfig(alias, key, value, local);
 }
 
-function getConfigPath(local = false) {
-  return getTargetConfigPath(local);
-}
-
 function validateRepository(alias = null) {
   const config = getConfig(alias);
   const repo = config ? config.repository : '';
@@ -255,10 +251,6 @@ function validateRepository(alias = null) {
   return repo;
 }
 
-function loadConfig() {
-  return getActiveConfig();
-}
-
 module.exports = {
   getAllConfigs,
   getActiveConfigName,
@@ -271,13 +263,7 @@ module.exports = {
   updateConfig,
   getConfigValue,
   setConfigValue,
-  getConfigPath,
   validateRepository,
   isValidAlias,
-  loadConfig,
-  DEFAULT_CONFIG: DEFAULT_CONFIG_VALUES,
-  CONFIG_FILE_NAME,
-  CLI_BASE_DIR,
-  GLOBAL_CONFIG_PATH,
-  LOCAL_CONFIG_PATH
+  DEFAULT_CONFIG: DEFAULT_CONFIG_VALUES
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,10 +11,6 @@ const { getActiveConfig, validateRepository } = require('./config');
 
 const execAsync = promisify(exec);
 
-function getRepoUrl() {
-  return getActiveConfig().repository;
-}
-
 function getCacheDir() {
   return getActiveConfig().cacheDir;
 }
@@ -363,10 +359,7 @@ async function ensureGitIdentity(targetCwd, fallbackCwd = null) {
 }
 
 module.exports = {
-  getRepoUrl,
   getCacheDir,
-  getSourceDir,
-  getTargetDir,
   getCursorSourceDir,
   getProjectSpecificPattern,
   getIgnoreList,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {


### PR DESCRIPTION
Removes duplicate error logging when pull fails in the TUI and cleans up unused exports and inline requires.

**Active Changes**
- **TUI:** Error shown once (loader.fail + suggestions) instead of three times; flow continues to "Back to menu?" instead of exiting
- **sync:** Removed redundant `console.error` in catch (loader.fail already prints it)
- **Dead code:** Removed `getRepoUrl`, `getSourceDir`/`getTargetDir` exports (utils); `getConfigPath`, `loadConfig`, path constants (config)
- **Imports:** `getProjectSpecificPattern` at top in sync, status, push; removed inline requires

**Database Changes**
None

**Environment Variables**
None

**Testing**
- Run `crules` → choose Pull when there are local changes → error appears once and menu continues