### PR TITLE
feat(cli): config scopes, update notice, hygiene, CI, npm + GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - run: npm ci
-      - run: npm run format:check
-      - run: npm test
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Check Prettier (format:check)
+        run: npm run format:check
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.x', '24.x']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ on:
     tags:
       - 'v*'
 
-# OIDC for npm trusted publishing (no NPM_TOKEN secret).
+# OIDC for npm trusted publishing; contents:write for GitHub Release (default GITHUB_TOKEN).
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -31,3 +31,10 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,26 @@ on:
     tags:
       - 'v*'
 
+# OIDC for npm trusted publishing (no NPM_TOKEN secret).
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
 
+      # Trusted publishing requires Node >= 22.14 and npm CLI >= 11.5.1 (see npm docs).
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
+      - name: Ensure npm 11.5.1+ (trusted publishing)
+        run: npm install -g npm@^11.5.1
+
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Ensure npm 11.5.1+ (trusted publishing)
         run: npm install -g npm@^11.5.1
 
-      - run: npm ci
-      - run: npm publish --access public
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish --access public

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "arrowParens": "always"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Save. npm does not validate this until the next publish—double-check spelling.
 
 1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
 2. Create and push a tag matching that version, e.g. `v1.2.3`.
-3. The **Release** workflow runs on `v*` tags and publishes with OIDC.
+3. The **Release** workflow runs on `v*` tags: it publishes to npm with OIDC, then creates a **GitHub Release** for that tag (auto-generated release notes). If `npm publish` fails, no release is created.
 
 Optional hardening after a successful publish: package **Settings** → **Publishing access** → restrict token-based publishes (“disallow tokens” / require 2FA) so only trusted publishing can ship releases.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
    npm install
    ```
 
+   Use **Node.js 20 or later** (see `engines` in `package.json`).
+
 3. Install globally for testing your changes:
 
    ```bash
@@ -84,6 +86,13 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
    crules status
    ```
 
+5. Automated checks (run before opening a PR):
+
+   ```bash
+   npm run format:check
+   npm test
+   ```
+
 ## Project Structure
 
 - `bin/` - CLI entry point
@@ -91,12 +100,21 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
   - `commands/` - Command handlers
   - `config.js` - Configuration management
   - `utils.js` - Shared utilities
+- `test/` - `node:test` unit tests
 
 ## Important Notes
 
 - **This repository does not contain cursor rules** - it is a generic CLI tool for syncing cursor rules from any repository
 - **Do not add `.cursor` folder or cursor rules to this repository** - contributors should focus on improving the CLI tool itself
 - End users configure their own cursor rules repositories separately
+
+## Releasing (maintainers)
+
+1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
+2. Create and push an annotated tag matching that version, e.g. `v1.2.3`.
+3. The **Release** workflow publishes to npm when the tag is pushed.
+
+Configure the **`NPM_TOKEN`** repository secret (npm automation token with publish permission). Without it, the workflow cannot authenticate to the registry.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,11 +110,27 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
 
 ## Releasing (maintainers)
 
-1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
-2. Create and push an annotated tag matching that version, e.g. `v1.2.3`.
-3. The **Release** workflow publishes to npm when the tag is pushed.
+Publishing uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC from GitHub Actions). You do **not** store an `NPM_TOKEN` for releases.
 
-Configure the **`NPM_TOKEN`** repository secret (npm automation token with publish permission). Without it, the workflow cannot authenticate to the registry.
+### One-time: link the package to this workflow
+
+On [npmjs.com](https://www.npmjs.com/) → your package → **Settings** → **Trusted Publisher** (or **Publishing access** → trusted publishing, depending on UI):
+
+1. Choose **GitHub Actions**.
+2. **Repository:** `eyyMinda/CRules-CLI` (must match `repository.url` in `package.json` exactly).
+3. **Workflow filename:** `release.yml` (filename only, case-sensitive, including `.yml`).
+
+Save. npm does not validate this until the next publish—double-check spelling.
+
+### Each release
+
+1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
+2. Create and push a tag matching that version, e.g. `v1.2.3`.
+3. The **Release** workflow runs on `v*` tags and publishes with OIDC.
+
+Optional hardening after a successful publish: package **Settings** → **Publishing access** → restrict token-based publishes (“disallow tokens” / require 2FA) so only trusted publishing can ship releases.
+
+**Private npm dependencies:** Trusted publishing only covers `npm publish`. If you ever add private packages, use a **read-only** granular token for `npm ci` only (`NODE_AUTH_TOKEN`), not for publish—see npm’s “Handling private dependencies” in the trusted publishers doc.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm install -g crules-cli
 npm install -g git+https://github.com/eyyMinda/CRules-CLI.git
 ```
 
+**Requirements:** Node.js **20+** (aligned with dependency baseline; install from [nodejs.org](https://nodejs.org/) or your version manager).
+
 ## Quick Start
 
 **⚠️ Important:** This CLI tool requires you to configure your own cursor rules repository. The package does not include any cursor rules.

--- a/bin/crules.js
+++ b/bin/crules.js
@@ -111,7 +111,10 @@ program
       // For edit command: action=edit, key=alias, value=configKey, extra=configValue
       // Or use --key and --value options
       if (action === 'edit' && (options.key || options.value)) {
-        await configCommand(action, key, options.key || value, { ...options, editValue: options.value || extra });
+        await configCommand(action, key, options.key || value, {
+          ...options,
+          editValue: options.value || extra
+        });
       } else if (action === 'edit' && extra) {
         // edit alias key value format
         await configCommand(action, key, value, { ...options, editValue: extra });

--- a/bin/crules.js
+++ b/bin/crules.js
@@ -9,6 +9,7 @@ const diffCommand = require('../lib/commands/diff');
 const configCommand = require('../lib/commands/config');
 const ignoreCommand = require('../lib/commands/ignore');
 const runTUI = require('../lib/commands/tui');
+const { maybePrintUpdateNotice } = require('../lib/version-check');
 
 const program = new Command();
 
@@ -123,11 +124,31 @@ program
   });
 
 const args = process.argv.slice(2);
-if (args.length === 0) {
-  runTUI().catch((err) => {
+const argvQuiet = args.includes('-q') || args.includes('--quiet');
+const skipUpdateNotice =
+  args.includes('--help') ||
+  args.includes('-h') ||
+  args.includes('--version') ||
+  args.includes('-V');
+
+(async () => {
+  if (args.length === 0) {
+    await maybePrintUpdateNotice({ quiet: false });
+    try {
+      await runTUI();
+    } catch (err) {
+      console.error(err.message || err);
+      process.exit(1);
+    }
+    return;
+  }
+  if (!skipUpdateNotice) {
+    await maybePrintUpdateNotice({ quiet: argvQuiet });
+  }
+  try {
+    await program.parseAsync();
+  } catch (err) {
     console.error(err.message || err);
     process.exit(1);
-  });
-} else {
-  program.parse();
-}
+  }
+})();

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,8 +1,15 @@
+const fs = require('fs');
 const {
+  CONFIG_FILE_NAME,
+  LOCAL_CONFIG_PATH,
   getAllConfigs,
+  loadLocalOnlyConfigs,
+  getActiveScope,
   getActiveConfigName,
   getActiveConfig,
   getConfig,
+  getConfigFromData,
+  getConfigValueFromData,
   setActiveConfig,
   createConfig,
   deleteConfig,
@@ -41,22 +48,75 @@ function displayConfigList(configs, activeName) {
 }
 
 async function configListCommand(options) {
+  const local = options.local || false;
+
+  if (local) {
+    if (!fs.existsSync(LOCAL_CONFIG_PATH)) {
+      console.log(`\nℹ️  No local ${CONFIG_FILE_NAME} in this directory.\n`);
+      return;
+    }
+    if (getActiveScope() === 'global') {
+      console.log(
+        '\nℹ️  Active config is global; listing local file only (not the active selection for pull/push).\n'
+      );
+    }
+    const data = loadLocalOnlyConfigs();
+    const activeName = data.active || 'default';
+    displayConfigList(data.configs, activeName);
+    console.log(`⚙️  Local file — active alias: ${activeName}`);
+    console.log('⚙️  Use crules config use -l <alias> to set active in the local file');
+    return;
+  }
+
   const allConfigs = getAllConfigs();
   const activeName = getActiveConfigName();
+  const scope = getActiveScope();
   displayConfigList(allConfigs.configs, activeName);
-  console.log(`⚙️  Active config: ${activeName}`);
+  console.log(`⚙️  Active config: ${activeName} (active scope: ${scope})`);
   console.log(`⚙️  Switch configs using: crules config use <alias>`);
 }
 
 async function configGetCommand(key, options) {
   const alias = options.alias || null;
+  const local = options.local || false;
+
+  if (local) {
+    if (!fs.existsSync(LOCAL_CONFIG_PATH)) {
+      console.log(`\nℹ️  No local ${CONFIG_FILE_NAME} in this directory.\n`);
+      return;
+    }
+    if (getActiveScope() === 'global') {
+      console.log(
+        '\nℹ️  Active config is global; showing local file only (not the active selection for pull/push).\n'
+      );
+    }
+    const data = loadLocalOnlyConfigs();
+    if (!key) {
+      const config = getConfigFromData(data, alias);
+      const displayAlias = alias || (data.active || 'default');
+      displayConfig(config, displayAlias);
+      console.log(`⚙️  Local file only. Omit -l to see merged active config used by pull/push.`);
+      console.log(`⚙️  Use 'crules config get <key>' to get a specific value`);
+      return;
+    }
+    const value = getConfigValueFromData(data, key, alias);
+    if (value === undefined) {
+      console.error(`\n❌ Configuration key '${key}' not found (in local file)`);
+      console.log(`\nAvailable keys: ${Object.keys(DEFAULT_CONFIG).join(', ')}`);
+      return;
+    }
+    displayConfigValue(key, value);
+    return;
+  }
 
   if (!key) {
     const config = getConfig(alias);
     const displayAlias = alias || getActiveConfigName();
     displayConfig(config, displayAlias);
+    console.log(`⚙️  Active scope: ${getActiveScope()} (where the active alias is stored)`);
     console.log(`⚙️  Use 'crules config get <key>' to get a specific value`);
     console.log(`⚙️  Use 'crules config set <key> <value>' to set a value`);
+    console.log(`⚙️  Use 'crules config get -l' to inspect local file only`);
     return;
   }
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -93,7 +93,7 @@ async function configGetCommand(key, options) {
     const data = loadLocalOnlyConfigs();
     if (!key) {
       const config = getConfigFromData(data, alias);
-      const displayAlias = alias || (data.active || 'default');
+      const displayAlias = alias || data.active || 'default';
       displayConfig(config, displayAlias);
       console.log(`⚙️  Local file only. Omit -l to see merged active config used by pull/push.`);
       console.log(`⚙️  Use 'crules config get <key>' to get a specific value`);
@@ -191,7 +191,9 @@ async function configCreateCommand(alias, options) {
 
   if (!isValidAlias(alias)) {
     console.error('\n❌ Invalid alias');
-    console.log('Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    console.log(
+      'Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
+    );
     return;
   }
 
@@ -220,7 +222,9 @@ async function configCreateCommand(alias, options) {
     if (repository) {
       console.log(`   Repository: ${repository}`);
     } else {
-      console.log(`   ⚙️  Configure repository using: crules config edit ${alias} repository <url>`);
+      console.log(
+        `   ⚙️  Configure repository using: crules config edit ${alias} repository <url>`
+      );
     }
   } catch (error) {
     console.error(`\n❌ Failed to create config: ${error.message}`);
@@ -317,7 +321,9 @@ async function configRenameCommand(oldAlias, newAlias, options) {
 
   if (!isValidAlias(newAlias)) {
     console.error('\n❌ Invalid new alias');
-    console.log('Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    console.log(
+      'Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
+    );
     return;
   }
 

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -22,7 +22,7 @@ async function showDiff(filePath, options) {
     const sourceContent = await getFileContent(sourcePath);
 
     if (!projectContent && !sourceContent) {
-    throw new Error(`File not found: ${filePath}`);
+      throw new Error(`File not found: ${filePath}`);
     }
 
     if (!projectContent) {
@@ -91,7 +91,9 @@ async function showDiff(filePath, options) {
       }
     }
 
-    const summary = [removedCount && `${removedCount} removed`, addedCount && `${addedCount} added`].filter(Boolean).join(', ');
+    const summary = [removedCount && `${removedCount} removed`, addedCount && `${addedCount} added`]
+      .filter(Boolean)
+      .join(', ');
     loader?.stop();
     out(`\n📄 File: ${filePath}`);
     out('='.repeat(60));
@@ -115,7 +117,7 @@ async function diffCommand(filePath, options) {
   } catch (error) {
     console.error('\n❌ Error showing diff:', error.message);
     if (error.suggestions) {
-      error.suggestions.forEach(suggestion => console.log(`   💡 ${suggestion}`));
+      error.suggestions.forEach((suggestion) => console.log(`   💡 ${suggestion}`));
     }
     if (options.verbose && error.stderr) {
       console.error(error.stderr);

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -232,14 +232,11 @@ async function pushToRemote(cacheDir, options = {}) {
             ]
           );
         }
-        throw createError(
-          `Failed to pull remote changes: ${pullError.message}`,
-          [
-            'Check your network connection',
-            'Verify repository access permissions',
-            'Try manually: git pull (in cache directory)'
-          ]
-        );
+        throw createError(`Failed to pull remote changes: ${pullError.message}`, [
+          'Check your network connection',
+          'Verify repository access permissions',
+          'Try manually: git pull (in cache directory)'
+        ]);
       }
       return;
     }
@@ -347,12 +344,11 @@ async function pushCommand(options) {
     loader?.start('Pushing to repository...');
     await pushChanges(changes, options);
     loader?.stop();
-
   } catch (error) {
     loader?.fail(error.message);
     console.error('\n❌ Error pushing changes:', error.message);
     if (error.suggestions) {
-      error.suggestions.forEach(suggestion => console.log(`   💡 ${suggestion}`));
+      error.suggestions.forEach((suggestion) => console.log(`   💡 ${suggestion}`));
     }
     if (verbose && error.stderr) {
       console.error(error.stderr);

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -71,7 +71,7 @@ async function getStatus() {
 
   const cacheDir = getCacheDir();
   const remoteDiffPaths = await getRemoteDiffPaths(cacheDir);
-  const remoteDiffSet = new Set(remoteDiffPaths.map(p => p.replace(/\\/g, '/')));
+  const remoteDiffSet = new Set(remoteDiffPaths.map((p) => p.replace(/\\/g, '/')));
 
   const trulySynced = [];
   for (const relPath of status.synced) {
@@ -92,25 +92,25 @@ function displayStatus(status, out = console.log) {
 
   if (status.added.length > 0) {
     out(`✨ New files (${status.added.length}):`);
-    status.added.forEach(file => out(`   + ${file}`));
+    status.added.forEach((file) => out(`   + ${file}`));
     out('');
   }
 
   if (status.modified.length > 0) {
     out(`📝 Modified - local changes (${status.modified.length}):`);
-    status.modified.forEach(file => out(`   ~ ${file}`));
+    status.modified.forEach((file) => out(`   ~ ${file}`));
     out('');
   }
 
   if (status.deleted.length > 0) {
     out(`🗑️  Deleted files (${status.deleted.length}):`);
-    status.deleted.forEach(file => out(`   - ${file}`));
+    status.deleted.forEach((file) => out(`   - ${file}`));
     out('');
   }
 
   if (status.outdated.length > 0) {
     out(`⟳  Outdated - remote has updates (${status.outdated.length}):`);
-    status.outdated.forEach(file => out(`   ○ ${file}`));
+    status.outdated.forEach((file) => out(`   ○ ${file}`));
     out('');
   }
 
@@ -141,12 +141,11 @@ async function statusCommand(options) {
     const status = await getStatus();
     loader?.stop();
     displayStatus(status, out);
-
   } catch (error) {
     loader?.fail(error.message);
     console.error('\n❌ Error checking status:', error.message);
     if (error.suggestions) {
-      error.suggestions.forEach(suggestion => console.log(`   💡 ${suggestion}`));
+      error.suggestions.forEach((suggestion) => console.log(`   💡 ${suggestion}`));
     }
     if (options.verbose && error.stderr) {
       console.error(error.stderr);

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -125,11 +125,10 @@ async function syncCommand(options) {
     if (Object.keys(backup).length > 0) {
       out(`\n💡 Preserved ${Object.keys(backup).length} project-specific file(s)`);
     }
-
   } catch (error) {
     loader?.fail(error.message);
     if (error.suggestions) {
-      error.suggestions.forEach(suggestion => console.log(`   💡 ${suggestion}`));
+      error.suggestions.forEach((suggestion) => console.log(`   💡 ${suggestion}`));
     }
     if (options.verbose && error.stderr) {
       console.error(error.stderr);

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -10,7 +10,7 @@ const { ensureCache } = require('../utils');
 const CHOICES = {
   pull: { name: 'Pull - Get latest from repository', value: 'pull' },
   push: { name: 'Push - Push local changes', value: 'push' },
-  status: { name: 'Status - See what\'s different', value: 'status' },
+  status: { name: "Status - See what's different", value: 'status' },
   diff: { name: 'Diff - View diff for a file', value: 'diff' },
   config: { name: 'Config - Manage configuration', value: 'config' },
   ignore: { name: 'Ignore - Manage ignore list', value: 'ignore' },

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,9 +46,7 @@ function localConfigEntryInGitignore(content) {
     const t = line.trim();
     if (!t || t.startsWith('#')) return false;
     return (
-      t === CONFIG_FILE_NAME ||
-      t === `/${CONFIG_FILE_NAME}` ||
-      t.endsWith(`/${CONFIG_FILE_NAME}`)
+      t === CONFIG_FILE_NAME || t === `/${CONFIG_FILE_NAME}` || t.endsWith(`/${CONFIG_FILE_NAME}`)
     );
   });
 }
@@ -197,7 +195,9 @@ function getActiveConfigName() {
 function getActiveConfig() {
   const configData = loadAllConfigs();
   const activeName = configData.active || 'default';
-  return configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES };
+  return (
+    configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES }
+  );
 }
 
 function getConfig(alias) {
@@ -225,10 +225,14 @@ function setActiveConfig(alias, local = false) {
 
 function createConfig(alias, configData = null, local = false) {
   if (!alias || alias === 'default') {
-    throw new Error('Cannot create config with alias "default". Use "default" config or create a named config.');
+    throw new Error(
+      'Cannot create config with alias "default". Use "default" config or create a named config.'
+    );
   }
   if (!isValidAlias(alias)) {
-    throw new Error('Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    throw new Error(
+      'Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
+    );
   }
   const configPath = getTargetConfigPath(local);
   const allConfigs = loadAllConfigs();
@@ -259,7 +263,9 @@ function deleteConfig(alias, local = false) {
     throw new Error(`Config '${alias}' does not exist`);
   }
   if (allConfigs.active === alias) {
-    throw new Error(`Cannot delete active config '${alias}'. Switch to another config first using 'crules config use <alias>'.`);
+    throw new Error(
+      `Cannot delete active config '${alias}'. Switch to another config first using 'crules config use <alias>'.`
+    );
   }
   const fileConfig = loadConfigFile(configPath) || { configs: {} };
   if (!fileConfig.configs) fileConfig.configs = {};
@@ -273,7 +279,9 @@ function renameConfig(oldAlias, newAlias, local = false) {
     throw new Error('Cannot rename "default" config');
   }
   if (!isValidAlias(newAlias)) {
-    throw new Error('Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.');
+    throw new Error(
+      'Invalid alias. Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
+    );
   }
   const configPath = getTargetConfigPath(local);
   const allConfigs = loadAllConfigs();
@@ -285,7 +293,10 @@ function renameConfig(oldAlias, newAlias, local = false) {
   }
   const fileConfig = loadConfigFile(configPath) || { configs: {} };
   if (!fileConfig.configs) fileConfig.configs = {};
-  fileConfig.configs[newAlias] = { ...fileConfig.configs[oldAlias], cacheDir: path.join(CLI_BASE_DIR, newAlias) };
+  fileConfig.configs[newAlias] = {
+    ...fileConfig.configs[oldAlias],
+    cacheDir: path.join(CLI_BASE_DIR, newAlias)
+  };
   delete fileConfig.configs[oldAlias];
   if (fileConfig.active === oldAlias) fileConfig.active = newAlias;
   ensureConfigDir(configPath);
@@ -328,10 +339,10 @@ function validateRepository(alias = null) {
     const activeName = alias || getActiveConfigName();
     throw new Error(
       `Repository not configured for config '${activeName}'. Please set it using:\n` +
-      `  crules config set repository <your-repo-url>\n` +
-      `  crules config edit ${activeName} repository <your-repo-url>\n\n` +
-      'Example:\n' +
-      '  crules config set repository https://github.com/username/cursor-rules.git'
+        `  crules config set repository <your-repo-url>\n` +
+        `  crules config edit ${activeName} repository <your-repo-url>\n\n` +
+        'Example:\n' +
+        '  crules config set repository https://github.com/username/cursor-rules.git'
     );
   }
   return repo;
@@ -340,7 +351,9 @@ function validateRepository(alias = null) {
 function getConfigFromData(configData, alias) {
   if (alias) return configData.configs[alias] || null;
   const activeName = configData.active || 'default';
-  return configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES };
+  return (
+    configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES }
+  );
 }
 
 function getConfigValueFromData(configData, key, alias = null) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,6 +40,65 @@ function loadConfigFile(configPath) {
   }
 }
 
+function saveConfigFile(configPath, configData) {
+  try {
+    fs.writeFileSync(configPath, JSON.stringify(configData, null, 2) + '\n', 'utf8');
+    return true;
+  } catch (error) {
+    throw new Error(`Failed to write config: ${error.message}`);
+  }
+}
+
+function normalizeConfigData(configData) {
+  if (!configData.configs.default) {
+    configData.configs.default = { ...DEFAULT_CONFIG_VALUES };
+  }
+  for (const alias in configData.configs) {
+    const config = configData.configs[alias];
+    if (config.cacheDir && config.cacheDir.startsWith('~')) {
+      config.cacheDir = config.cacheDir.replace('~', os.homedir());
+    }
+    if (!Array.isArray(config.ignoreList)) config.ignoreList = [];
+    if (config.sourcePath === undefined) config.sourcePath = DEFAULT_CONFIG_VALUES.sourcePath;
+    if (config.targetPath === undefined) config.targetPath = DEFAULT_CONFIG_VALUES.targetPath;
+    if (alias !== 'default' && !config.cacheDir) {
+      config.cacheDir = path.join(CLI_BASE_DIR, alias);
+    }
+  }
+  return configData;
+}
+
+function mergeLayerOntoBase(base, layer) {
+  if (!layer) return base;
+  const next = { ...base, ...layer };
+  if (layer.configs) {
+    next.configs = { ...base.configs, ...layer.configs };
+  }
+  return next;
+}
+
+/** Defaults + global file only (no project local overlay). */
+function loadGlobalOnlyConfigs() {
+  let configData = {
+    active: 'default',
+    configs: { default: { ...DEFAULT_CONFIG_VALUES } }
+  };
+  const globalConfig = loadConfigFile(GLOBAL_CONFIG_PATH);
+  configData = mergeLayerOntoBase(configData, globalConfig);
+  return normalizeConfigData(configData);
+}
+
+/** Defaults + local file only (no home global overlay). */
+function loadLocalOnlyConfigs() {
+  let configData = {
+    active: 'default',
+    configs: { default: { ...DEFAULT_CONFIG_VALUES } }
+  };
+  const localConfig = loadConfigFile(LOCAL_CONFIG_PATH);
+  configData = mergeLayerOntoBase(configData, localConfig);
+  return normalizeConfigData(configData);
+}
+
 function loadAllConfigs() {
   let configData = {
     active: 'default',
@@ -64,33 +123,27 @@ function loadAllConfigs() {
     }
   }
 
-  if (!configData.configs.default) {
-    configData.configs.default = { ...DEFAULT_CONFIG_VALUES };
-  }
-
-  for (const alias in configData.configs) {
-    const config = configData.configs[alias];
-    if (config.cacheDir && config.cacheDir.startsWith('~')) {
-      config.cacheDir = config.cacheDir.replace('~', os.homedir());
-    }
-    if (!Array.isArray(config.ignoreList)) config.ignoreList = [];
-    if (config.sourcePath === undefined) config.sourcePath = DEFAULT_CONFIG_VALUES.sourcePath;
-    if (config.targetPath === undefined) config.targetPath = DEFAULT_CONFIG_VALUES.targetPath;
-    if (alias !== 'default' && !config.cacheDir) {
-      config.cacheDir = path.join(CLI_BASE_DIR, alias);
-    }
-  }
-
-  return configData;
+  return normalizeConfigData(configData);
 }
 
-function saveConfigFile(configPath, configData) {
-  try {
-    fs.writeFileSync(configPath, JSON.stringify(configData, null, 2) + '\n', 'utf8');
-    return true;
-  } catch (error) {
-    throw new Error(`Failed to write config: ${error.message}`);
+/**
+ * Where the effective `active` alias is authored for this project:
+ * local file defines `active` → local; otherwise global.
+ */
+function getActiveScope() {
+  const localRaw = loadConfigFile(LOCAL_CONFIG_PATH);
+  if (localRaw && Object.prototype.hasOwnProperty.call(localRaw, 'active')) {
+    return 'local';
   }
+  return 'global';
+}
+
+function removeActiveFromLocalConfig() {
+  if (!pathExists(LOCAL_CONFIG_PATH)) return;
+  const fileConfig = loadConfigFile(LOCAL_CONFIG_PATH);
+  if (!fileConfig || !Object.prototype.hasOwnProperty.call(fileConfig, 'active')) return;
+  delete fileConfig.active;
+  saveConfigFile(LOCAL_CONFIG_PATH, fileConfig);
 }
 
 function getTargetConfigPath(local) {
@@ -134,7 +187,11 @@ function setActiveConfig(alias, local = false) {
   if (!fileConfig.configs) fileConfig.configs = {};
   fileConfig.active = alias;
   ensureConfigDir(configPath);
-  return saveConfigFile(configPath, fileConfig);
+  const ok = saveConfigFile(configPath, fileConfig);
+  if (!local) {
+    removeActiveFromLocalConfig();
+  }
+  return ok;
 }
 
 function createConfig(alias, configData = null, local = false) {
@@ -251,11 +308,31 @@ function validateRepository(alias = null) {
   return repo;
 }
 
+function getConfigFromData(configData, alias) {
+  if (alias) return configData.configs[alias] || null;
+  const activeName = configData.active || 'default';
+  return configData.configs[activeName] || configData.configs.default || { ...DEFAULT_CONFIG_VALUES };
+}
+
+function getConfigValueFromData(configData, key, alias = null) {
+  const config = getConfigFromData(configData, alias);
+  return config ? config[key] : undefined;
+}
+
 module.exports = {
+  CLI_BASE_DIR,
+  CONFIG_FILE_NAME,
+  GLOBAL_CONFIG_PATH,
+  LOCAL_CONFIG_PATH,
   getAllConfigs,
+  loadGlobalOnlyConfigs,
+  loadLocalOnlyConfigs,
+  getActiveScope,
   getActiveConfigName,
   getActiveConfig,
   getConfig,
+  getConfigFromData,
+  getConfigValueFromData,
   setActiveConfig,
   createConfig,
   deleteConfig,

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,9 +40,38 @@ function loadConfigFile(configPath) {
   }
 }
 
+function localConfigEntryInGitignore(content) {
+  const lines = content.split(/\r?\n/);
+  return lines.some((line) => {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) return false;
+    return (
+      t === CONFIG_FILE_NAME ||
+      t === `/${CONFIG_FILE_NAME}` ||
+      t.endsWith(`/${CONFIG_FILE_NAME}`)
+    );
+  });
+}
+
+/** Idempotent: ensure root .gitignore contains CRules block + local config filename. */
+function ensureCrulesGitignoreEntry() {
+  const gitignorePath = path.join(process.cwd(), '.gitignore');
+  let content = '';
+  if (pathExists(gitignorePath)) {
+    content = fs.readFileSync(gitignorePath, 'utf8');
+  }
+  if (localConfigEntryInGitignore(content)) return;
+  const block = `# CRules CLI\n${CONFIG_FILE_NAME}\n`;
+  const gap = content.length === 0 ? '' : content.endsWith('\n') ? '\n' : '\n\n';
+  fs.writeFileSync(gitignorePath, content + gap + block, 'utf8');
+}
+
 function saveConfigFile(configPath, configData) {
   try {
     fs.writeFileSync(configPath, JSON.stringify(configData, null, 2) + '\n', 'utf8');
+    if (configPath === LOCAL_CONFIG_PATH) {
+      ensureCrulesGitignoreEntry();
+    }
     return true;
   } catch (error) {
     throw new Error(`Failed to write config: ${error.message}`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,7 @@ function isPathIgnored(relPath, ignoreList) {
   const list = Array.isArray(ignoreList) ? ignoreList : getIgnoreList();
   const normalizedPath = relPath.replace(/\\/g, '/');
   return list.some(
-    pattern =>
+    (pattern) =>
       minimatch(normalizedPath, pattern, { matchBase: true }) || minimatch(normalizedPath, pattern)
   );
 }
@@ -94,7 +94,9 @@ async function ensureCache(verbose = false, options = {}) {
     try {
       await execAsync(`git clone ${repoUrl} "${cacheDir}"`);
     } catch (error) {
-      throw new Error(`Failed to clone repository: ${error.message}\nMake sure git is installed and the repository URL is correct.`);
+      throw new Error(
+        `Failed to clone repository: ${error.message}\nMake sure git is installed and the repository URL is correct.`
+      );
     }
   } else if (!skipPull) {
     if (verbose) console.log('🔄 Updating Cursor Rules repository...');
@@ -105,7 +107,9 @@ async function ensureCache(verbose = false, options = {}) {
       try {
         await execAsync('git fetch origin', { cwd: cacheDir });
       } catch (fetchError) {
-        throw new Error(`Failed to update repository: ${error.message}\nMake sure you have network access and git is properly configured.`);
+        throw new Error(
+          `Failed to update repository: ${error.message}\nMake sure you have network access and git is properly configured.`
+        );
       }
     }
   }
@@ -132,8 +136,8 @@ function getProjectSpecificFiles(targetDir) {
     const dirPath = path.join(targetDir, key);
     if (!pathExists(dirPath)) continue;
     const files = fs.readdirSync(dirPath);
-    projectSpecific[key] = files.filter(file =>
-      pattern.test(file) && (!ext || file.endsWith(ext))
+    projectSpecific[key] = files.filter(
+      (file) => pattern.test(file) && (!ext || file.endsWith(ext))
     );
   }
 
@@ -171,7 +175,10 @@ async function getFileContent(filePath) {
 
 async function getFileHash(content) {
   const crypto = require('crypto');
-  return crypto.createHash('md5').update(content || '').digest('hex');
+  return crypto
+    .createHash('md5')
+    .update(content || '')
+    .digest('hex');
 }
 
 function promptUser(question, defaultValue = null) {
@@ -185,7 +192,10 @@ function promptUser(question, defaultValue = null) {
     const d = String(defaultValue).toLowerCase();
     const isYesDefault = d === 'y' || d === 'yes';
     const yn = isYesDefault ? '[Y/n]' : '[y/N]';
-    prompt = `${question.trimEnd().replace(/\s*\([yYnN\/]+\)\s*:?\s*$/, '').trimEnd()} ${yn}: `;
+    prompt = `${question
+      .trimEnd()
+      .replace(/\s*\([yYnN\/]+\)\s*:?\s*$/, '')
+      .trimEnd()} ${yn}: `;
   }
 
   return new Promise((resolve) => {
@@ -217,10 +227,14 @@ function createLoader(message, quiet = false) {
 async function getGitStatus(cwd) {
   try {
     const { stdout } = await execAsync('git status --porcelain', { cwd });
-    return stdout.trim().split('\n').filter(line => line).map(line => {
-      const [status, ...fileParts] = line.trim().split(/\s+/);
-      return { status: status.substring(0, 2), file: fileParts.join(' ') };
-    });
+    return stdout
+      .trim()
+      .split('\n')
+      .filter((line) => line)
+      .map((line) => {
+        const [status, ...fileParts] = line.trim().split(/\s+/);
+        return { status: status.substring(0, 2), file: fileParts.join(' ') };
+      });
   } catch {
     return [];
   }
@@ -251,7 +265,9 @@ async function getRemoteDiffPaths(cacheDir) {
 
   let remoteRef = 'origin/HEAD';
   try {
-    const { stdout: branch } = await execAsync('git rev-parse --abbrev-ref HEAD', { cwd: cacheDir });
+    const { stdout: branch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      cwd: cacheDir
+    });
     const br = branch.trim();
     if (br && br !== 'HEAD') {
       try {
@@ -270,8 +286,11 @@ async function getRemoteDiffPaths(cacheDir) {
       cwd: cacheDir
     });
     const lines = stdout.trim().split('\n').filter(Boolean);
-    const prefix = gitPath !== '.' ? new RegExp(`^${gitPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[/\\\\]`) : null;
-    return lines.map(p => (prefix ? p.replace(prefix, '') : p).replace(/\\/g, '/'));
+    const prefix =
+      gitPath !== '.'
+        ? new RegExp(`^${gitPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[/\\\\]`)
+        : null;
+    return lines.map((p) => (prefix ? p.replace(prefix, '') : p).replace(/\\/g, '/'));
   } catch {
     return [];
   }

--- a/lib/version-check.js
+++ b/lib/version-check.js
@@ -1,0 +1,143 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const { CLI_BASE_DIR } = require('./config');
+
+const CACHE_PATH = path.join(CLI_BASE_DIR, '.version-check.json');
+const CACHE_MS = 24 * 60 * 60 * 1000;
+const REGISTRY_HOST = 'registry.npmjs.org';
+const REGISTRY_PATH = '/crules-cli/latest';
+const TIMEOUT_MS = 4000;
+
+const ansi = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  yellow: '\x1b[33m'
+};
+
+function readCache() {
+  try {
+    if (!fs.existsSync(CACHE_PATH)) return null;
+    return JSON.parse(fs.readFileSync(CACHE_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(latest) {
+  try {
+    if (!fs.existsSync(CLI_BASE_DIR)) {
+      fs.mkdirSync(CLI_BASE_DIR, { recursive: true });
+    }
+    fs.writeFileSync(
+      CACHE_PATH,
+      JSON.stringify({ checkedAt: Date.now(), latest }) + '\n',
+      'utf8'
+    );
+  } catch {
+    // ignore cache write failures
+  }
+}
+
+function fetchLatestVersion() {
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        hostname: REGISTRY_HOST,
+        path: REGISTRY_PATH,
+        method: 'GET',
+        timeout: TIMEOUT_MS,
+        headers: { Accept: 'application/json' }
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            resolve(null);
+            return;
+          }
+          try {
+            const j = JSON.parse(raw);
+            resolve(typeof j.version === 'string' ? j.version : null);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
+/** True if semver-like `a` is strictly newer than `b` (numeric dot parts only). */
+function versionNewer(a, b) {
+  if (!a || !b || a === b) return false;
+  const pa = a.split('.').map((x) => parseInt(String(x).replace(/^\D+/, ''), 10) || 0);
+  const pb = b.split('.').map((x) => parseInt(String(x).replace(/^\D+/, ''), 10) || 0);
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x > y) return true;
+    if (x < y) return false;
+  }
+  return false;
+}
+
+function paint(text, code, useColor) {
+  if (!useColor) return text;
+  return `${code}${text}${ansi.reset}`;
+}
+
+/**
+ * If npm has a newer crules-cli than this install, print a short colored hint on stderr.
+ * Respects `quiet`; skips when CI is set. Uses a daily cache under ~/.crules-cli.
+ */
+async function maybePrintUpdateNotice({ quiet } = {}) {
+  if (quiet || process.env.CI) return;
+
+  let pkg;
+  try {
+    pkg = require('../package.json');
+  } catch {
+    return;
+  }
+  const current = pkg.version;
+  const now = Date.now();
+  const cached = readCache();
+  let latest = cached && typeof cached.latest === 'string' ? cached.latest : null;
+
+  const stale = !cached || !cached.checkedAt || now - cached.checkedAt > CACHE_MS;
+  if (stale) {
+    const fetched = await fetchLatestVersion();
+    if (fetched) {
+      latest = fetched;
+      writeCache(fetched);
+    } else if (latest) {
+      writeCache(latest);
+    } else {
+      return;
+    }
+  }
+
+  if (!latest || !versionNewer(latest, current)) return;
+
+  const useColor = process.stderr.isTTY === true;
+  const dim = (s) => paint(s, ansi.dim, useColor);
+  const yellow = (s) => paint(s, ansi.yellow, useColor);
+
+  console.error('');
+  console.error(`${yellow(`↳ New version on npm: ${latest}`)}${dim(` (installed ${current})`)}`);
+  console.error(dim('  npm install -g crules-cli@latest'));
+  console.error('');
+}
+
+module.exports = { maybePrintUpdateNotice };

--- a/lib/version-check.js
+++ b/lib/version-check.js
@@ -29,11 +29,7 @@ function writeCache(latest) {
     if (!fs.existsSync(CLI_BASE_DIR)) {
       fs.mkdirSync(CLI_BASE_DIR, { recursive: true });
     }
-    fs.writeFileSync(
-      CACHE_PATH,
-      JSON.stringify({ checkedAt: Date.now(), latest }) + '\n',
-      'utf8'
-    );
+    fs.writeFileSync(CACHE_PATH, JSON.stringify({ checkedAt: Date.now(), latest }) + '\n', 'utf8');
   } catch {
     // ignore cache write failures
   }

--- a/lib/version-check.js
+++ b/lib/version-check.js
@@ -136,4 +136,4 @@ async function maybePrintUpdateNotice({ quiet } = {}) {
   console.error('');
 }
 
-module.exports = { maybePrintUpdateNotice };
+module.exports = { maybePrintUpdateNotice, compareSemverGreater: versionNewer };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -19,7 +19,7 @@
         "crules": "bin/crules.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@inquirer/external-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.0.13",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.0.13",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -17,6 +17,9 @@
       },
       "bin": {
         "crules": "bin/crules.js"
+      },
+      "devDependencies": {
+        "prettier": "^3.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -706,6 +709,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/readable-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "install-global": "npm install -g .",
-    "format": "prettier --write \"bin/**/*.js\" \"lib/**/*.js\"",
-    "format:check": "prettier --check \"bin/**/*.js\" \"lib/**/*.js\""
+    "test": "node --test test/config.test.js test/version-check.test.js",
+    "format": "prettier --write \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\"",
+    "format:check": "prettier --check \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\""
   },
   "keywords": [
     "cursor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "crules-cli",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {
     "crules": "./bin/crules.js"
   },
   "scripts": {
-    "install-global": "npm install -g ."
+    "install-global": "npm install -g .",
+    "format": "prettier --write \"bin/**/*.js\" \"lib/**/*.js\"",
+    "format:check": "prettier --check \"bin/**/*.js\" \"lib/**/*.js\""
   },
   "keywords": [
     "cursor",
@@ -47,5 +49,8 @@
     "inquirer": "^8.2.7",
     "minimatch": "^10.2.4",
     "ora": "^9.3.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/eyyMinda/CRules-CLI#readme",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "bin",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cli-home-'));
+const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cli-proj-'));
+
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+const prevCwd = process.cwd();
+process.chdir(tmpProject);
+
+const config = require('../lib/config.js');
+
+after(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+});
+
+function wipeState() {
+  const cliDir = path.join(tmpHome, '.crules-cli');
+  if (fs.existsSync(cliDir)) fs.rmSync(cliDir, { recursive: true, force: true });
+  const lc = path.join(tmpProject, '.crules-cli-config.json');
+  if (fs.existsSync(lc)) fs.unlinkSync(lc);
+}
+
+beforeEach(() => wipeState());
+
+test('getActiveScope is global without local config file', () => {
+  assert.equal(config.getActiveScope(), 'global');
+});
+
+test('getActiveScope is local when local file defines active', () => {
+  fs.writeFileSync(
+    path.join(tmpProject, '.crules-cli-config.json'),
+    JSON.stringify({
+      active: 'default',
+      configs: { default: { repository: 'https://example.com/a.git' } }
+    })
+  );
+  assert.equal(config.getActiveScope(), 'local');
+});
+
+test('setActiveConfig global clears active from local file', () => {
+  config.createConfig('proj', { repository: 'https://example.com/r.git' }, false);
+  fs.writeFileSync(
+    path.join(tmpProject, '.crules-cli-config.json'),
+    JSON.stringify({ active: 'default', configs: {} })
+  );
+  assert.equal(config.getActiveScope(), 'local');
+  config.setActiveConfig('proj', false);
+  assert.equal(config.getActiveScope(), 'global');
+  const raw = JSON.parse(fs.readFileSync(path.join(tmpProject, '.crules-cli-config.json'), 'utf8'));
+  assert.equal(Object.prototype.hasOwnProperty.call(raw, 'active'), false);
+});
+
+test('loadGlobalOnlyConfigs does not include profiles only in local file', () => {
+  config.createConfig('gonly', { repository: 'https://g.test/repo.git' }, false);
+  config.createConfig('lonly', { repository: 'https://l.test/repo.git' }, true);
+  const g = config.loadGlobalOnlyConfigs();
+  assert.ok(g.configs.gonly);
+  assert.equal(g.configs.lonly, undefined);
+  const merged = config.getAllConfigs();
+  assert.ok(merged.configs.lonly);
+});

--- a/test/version-check.test.js
+++ b/test/version-check.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { compareSemverGreater } = require('../lib/version-check.js');
+
+test('compareSemverGreater', () => {
+  assert.equal(compareSemverGreater('1.2.0', '1.1.9'), true);
+  assert.equal(compareSemverGreater('1.1.9', '1.2.0'), false);
+  assert.equal(compareSemverGreater('1.0.0', '1.0.0'), false);
+  assert.equal(compareSemverGreater('2.0.0', '1.99.99'), true);
+});


### PR DESCRIPTION
## Summary

Improves how config is resolved and shown (global vs local active, `-l`), keeps local config out of git, surfaces newer npm versions in the CLI, and adds Node 20+ hygiene: Prettier, tests, CI, and a single **Release** workflow on `v*` tags that publishes to npm via trusted publishing (OIDC) and then opens a **GitHub Release** with generated notes.

## Active Changes

- Config: active scope labeling, merged vs local-only lists, `-l` for local file; clearing global active strips `active` from local JSON when appropriate.
- Local config writes append a `.crules-cli-config.json` entry in the project `.gitignore` when needed.
- Startup: optional registry version check (cached), stderr styling, skipped for help/version/quiet/CI.
- Tooling: `engines` Node ≥20, Prettier + scripts, `node:test` for config and semver helper, GitHub Actions CI on Node 20/24.
- Release: on `v*` tags, `npm publish` (OIDC, no publish token) then **Create GitHub Release** (`softprops/action-gh-release`, auto release notes); `contents: write` for the default `GITHUB_TOKEN`. CONTRIBUTING documents trusted publisher setup and this flow; workflow steps are named for clearer logs.

## Testing

- `npm run format:check` and `npm test` locally; CI green on PR and on `main` after merge.
- Smoke: `crules config get` / `list` with and without `-l`; optional version-check behavior.
- After a test tag (or real release): Release workflow completes, package appears on npm, **Releases** tab shows the new tag with generated notes.

## Technical Details

**Breaking / policy:** Node 20+ required at runtime. Trusted publisher on npm must point at this repo and `release.yml`. Re-running the workflow for the same tag may fail at npm publish (version already published); adjust or skip as needed.