### PR TITLE
bump: 1.1.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # npm publish uses package.json "version", not the git tag — catch mismatches before publishing.
+      - name: Verify package.json version matches tag
+        run: |
+          TAG_VER="${GITHUB_REF_NAME#v}"
+          PKG_VER=$(node -p "require('./package.json').version")
+          if [ "$TAG_VER" != "$PKG_VER" ]; then
+            echo "::error::package.json version is $PKG_VER but tag is $GITHUB_REF_NAME (expected $TAG_VER in package.json)"
+            exit 1
+          fi
+
       # Trusted publishing requires Node >= 22.14 and npm CLI >= 11.5.1 (see npm docs).
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.14] - 2026-03-26
+
+### Fixed
+
+- Release workflow verifies `package.json` `version` matches the pushed `v*` tag before `npm publish`, so the npm tarball and GitHub Release stay aligned.
+
+### Changed
+
+- CONTRIBUTING: release steps note that the tag must point at the version-bump commit (`npm publish` uses `package.json`, not the tag name).
+
 ## [1.0.3] - 2026-01-17
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Save. npm does not validate this until the next publish—double-check spelling.
 ### Each release
 
 1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
-2. Create and push a tag matching that version, e.g. `v1.2.3`.
+2. Create and push a tag matching that version, e.g. `v1.2.3` for `package.json` `1.2.3`. The tag must point at the **same commit** as the bump — npm uses `package.json`, not the tag name; the workflow fails if they disagree.
 3. The **Release** workflow runs on `v*` tags: it publishes to npm with OIDC, then creates a **GitHub Release** for that tag (auto-generated release notes). If `npm publish` fails, no release is created.
 
 Optional hardening after a successful publish: package **Settings** → **Publishing access** → restrict token-based publishes (“disallow tokens” / require 2FA) so only trusted publishing can ship releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {


### PR DESCRIPTION
- ci: verify package.json version matches v* tag before npm publish
- docs: CONTRIBUTING release note; CHANGELOG [1.1.14]