### PR TITLE
test: Vitest command coverage, config edit fix, and 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Check Prettier (format:check)
         run: npm run format:check
 
-      - name: Run tests
+      - name: Run Vitest (npm test)
         run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.0] - 2026-03-26
+
+### Added
+
+- Vitest coverage across commands and shared code: `status`, `push`, `sync` (pull), `diff`, `config` CLI dispatch, `ignore`, `utils`, and a minimal `tui` export check (alongside existing `config` and `version-check` tests).
+
+### Changed
+
+- Command internals call shared `utils` module members where tests need to spy or stub (e.g. git exec, remote diff paths, cache/path helpers).
+
+### Fixed
+
+- `crules config edit` passes Commander options through to the edit handler so flag-style usage behaves like positional arguments.
+
+### Documentation
+
+- README: Node **20+** in Requirements (aligned with `engines`); Contributing blurb for `npm test` / Vitest.
+- CONTRIBUTING: Vitest scripts, `vitest.config.mjs`, table of `test/*.test.js` files and conventions (temp dirs / `HOME`).
+
+---
+
 ## [1.1.15] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.15] - 2026-03-26
+
+### Added
+
+- Vitest for unit tests (`npm test` → `vitest run`, `npm run test:watch`).
+
+### Changed
+
+- Prettier includes `vitest.config.mjs`; CONTRIBUTING documents Vitest-based tests.
+
 ## [1.1.14] - 2026-03-26
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
   - `commands/` - Command handlers
   - `config.js` - Configuration management
   - `utils.js` - Shared utilities
-- `test/` - `node:test` unit tests
+- `test/` - Vitest unit tests (`npm test` → `vitest run`)
 
 ## Important Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,39 @@ Feature suggestions are welcome! Please open an issue with:
 
 Before submitting a PR:
 
-- Test all affected commands
+- Test all affected commands manually when behavior changes
 - Test on different operating systems if possible
 - Test edge cases and error conditions
 - Ensure backward compatibility
+- Run automated checks (below); add or extend Vitest specs in `test/` when you fix bugs or add behavior
+
+**Automated suite (Vitest 3, Node test environment):**
+
+| Script        | What it runs                                      |
+| ------------- | ------------------------------------------------- |
+| `npm test`    | `vitest run` — CI-style single pass               |
+| `npm run test:watch` | `vitest` — watch mode while developing     |
+
+**CI:** Push/PR to `main` or `master` runs `npm ci`, `npm run format:check`, and `npm test` (Vitest) on Node **20.x** and **24.x** — see `.github/workflows/ci.yml`.
+
+**Config:** `vitest.config.mjs` — `include: ['test/**/*.test.js']`, `environment: 'node'`, `pool: 'forks'`. Baseline: **49 tests**, **10** spec files (`npm test` to confirm after changes).
+
+**Specs (by area):**
+
+| File                     | Focus |
+| ------------------------ | ----- |
+| `test/config.test.js`    | `lib/config.js` load/save, aliases, paths |
+| `test/config-command.test.js` | `config` command: `edit` / `set` / `use`, temp config + reload |
+| `test/version-check.test.js` | Semver compare helper for update notice |
+| `test/status.test.js`    | `getStatus` buckets, outdated vs remote diff paths |
+| `test/push.test.js`      | Push flow helpers, `execAsync` / git sequences |
+| `test/sync.test.js`      | Pull: dry-run, modified guard, missing source, `--force` |
+| `test/diff.test.js`      | `diff` branches (missing, new, deleted, identical, verbose) |
+| `test/ignore.test.js`    | `ignore` add/list/remove, validation, temp config |
+| `test/utils.test.js`     | `createError`, ignore filtering helpers |
+| `test/tui.test.js`       | Default export + `runAction` export shape |
+
+Many tests use temporary directories and `HOME` overrides so they do not touch your real `~/.crules-cli`. Prefer the same pattern for new command tests.
 
 ## Development Setup
 
@@ -100,7 +129,8 @@ End users should install via `npm install -g crules-cli` (see [README.md](README
   - `commands/` - Command handlers
   - `config.js` - Configuration management
   - `utils.js` - Shared utilities
-- `test/` - Vitest unit tests (`npm test` → `vitest run`)
+- `test/` - Vitest unit tests (`npm test` → `vitest run`; see [Testing](#testing))
+- `vitest.config.mjs` - Vitest project config (included in Prettier format paths)
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ crules pull
 
 ## Requirements
 
-- Node.js >= 14.0.0
+- Node.js **20+** (same as `engines` in `package.json`)
 - Git installed and configured
 - Git identity configured (user.name and user.email) - usually already set globally
 - Network access (for repository operations)
@@ -655,6 +655,8 @@ crules pull
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
+
+After cloning: `npm install`, then `npm test` (Vitest) and `npm run format:check` before opening a PR. See CONTRIBUTING.md for the test layout and `vitest.config.mjs`.
 
 ## License
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -354,7 +354,8 @@ async function configCommand(action, key, value, options) {
     } else if (action === 'delete') {
       await configDeleteCommand(key, options); // key is alias here
     } else if (action === 'edit') {
-      await configEditCommand(key, value, options); // key is alias, value is config key
+      // key = alias, value = config key; options carries editValue / --key / --value from CLI
+      await configEditCommand(key, value, undefined, options);
     } else if (action === 'rename') {
       await configRenameCommand(key, value, options); // key is old alias, value is new alias
     } else {

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -1,25 +1,18 @@
 const path = require('path');
 const diff = require('diff');
-const {
-  getCursorDir,
-  ensureCache,
-  getFileContent,
-  getFileHash,
-  getCursorSourceDir,
-  createOutput,
-  createLoader
-} = require('../utils');
+const utils = require('../utils');
+const { createOutput, createLoader } = utils;
 
 async function showDiff(filePath, options) {
   const out = createOutput(options.quiet);
   const loader = createLoader('Loading diff...', options.quiet);
   try {
-    const cursorDir = getCursorDir();
+    const cursorDir = utils.getCursorDir();
     const projectPath = path.join(cursorDir, filePath);
-    const sourcePath = path.join(getCursorSourceDir(), filePath);
+    const sourcePath = path.join(utils.getCursorSourceDir(), filePath);
 
-    const projectContent = await getFileContent(projectPath);
-    const sourceContent = await getFileContent(sourcePath);
+    const projectContent = await utils.getFileContent(projectPath);
+    const sourceContent = await utils.getFileContent(sourcePath);
 
     if (!projectContent && !sourceContent) {
       throw new Error(`File not found: ${filePath}`);
@@ -41,8 +34,8 @@ async function showDiff(filePath, options) {
       return;
     }
 
-    const projectHash = await getFileHash(projectContent);
-    const sourceHash = await getFileHash(sourceContent);
+    const projectHash = await utils.getFileHash(projectContent);
+    const sourceHash = await utils.getFileHash(sourceContent);
 
     if (projectHash === sourceHash) {
       loader?.stop();
@@ -112,7 +105,7 @@ async function diffCommand(filePath, options) {
       throw new Error('File path is required');
     }
 
-    await ensureCache(options.verbose && !options.quiet);
+    await utils.ensureCache(options.verbose && !options.quiet);
     await showDiff(filePath, options);
   } catch (error) {
     console.error('\n❌ Error showing diff:', error.message);

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const diff = require('diff');
 const fsPromises = require('fs').promises;
+const utils = require('../utils');
 const {
   getCursorDir,
   ensureCache,
@@ -9,7 +10,6 @@ const {
   getFileHash,
   promptUser,
   getGitStatus,
-  execAsync,
   getCursorSourceDir,
   getProjectSpecificFiles,
   getProjectSpecificPattern,
@@ -20,7 +20,7 @@ const {
   filterFilesByIgnore,
   createOutput,
   createLoader
-} = require('../utils');
+} = utils;
 const { getActiveConfig } = require('../config');
 
 async function compareFiles() {
@@ -183,7 +183,7 @@ async function pushToRemote(cacheDir, options = {}) {
   const noPull = options.noPull || false;
 
   try {
-    await execAsync('git push', { cwd: cacheDir });
+    await utils.execAsync('git push', { cwd: cacheDir });
   } catch (error) {
     const combinedOutput = `${error.stdout || ''}\n${error.stderr || ''}`;
     const missingUpstream =
@@ -192,7 +192,7 @@ async function pushToRemote(cacheDir, options = {}) {
       combinedOutput.includes('have no upstream');
 
     if (missingUpstream) {
-      await execAsync('git push -u origin HEAD', { cwd: cacheDir });
+      await utils.execAsync('git push -u origin HEAD', { cwd: cacheDir });
       return;
     }
 
@@ -216,9 +216,9 @@ async function pushToRemote(cacheDir, options = {}) {
       const out = createOutput(options.quiet);
       out('🔄 Remote has changes, pulling latest updates...');
       try {
-        await execAsync('git pull --rebase', { cwd: cacheDir });
+        await utils.execAsync('git pull --rebase', { cwd: cacheDir });
         out('✅ Successfully integrated remote changes');
-        await execAsync('git push', { cwd: cacheDir });
+        await utils.execAsync('git push', { cwd: cacheDir });
       } catch (pullError) {
         const pullOutput = `${pullError.stdout || ''}\n${pullError.stderr || ''}`;
         if (pullOutput.includes('CONFLICT') || pullOutput.includes('conflict')) {
@@ -291,13 +291,13 @@ async function pushChanges(changes, options) {
   out('\n📤 Committing changes...');
   const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
   const gitAddPath = sourcePath || '.';
-  await execAsync(`git add "${gitAddPath}"`, { cwd: cacheDir });
+  await utils.execAsync(`git add "${gitAddPath}"`, { cwd: cacheDir });
 
   const config = getActiveConfig();
   const summary = `${changes.added.length} added, ${changes.modified.length} modified, ${changes.deleted.length} deleted`;
   const commitMessage = config.commitMessage.replace('{summary}', summary);
 
-  await execAsync(`git commit -m "${commitMessage}"`, { cwd: cacheDir });
+  await utils.execAsync(`git commit -m "${commitMessage}"`, { cwd: cacheDir });
 
   out('📤 Pushing to repository...');
   await pushToRemote(cacheDir, { noPull: options.noPull, quiet: options.quiet });
@@ -358,3 +358,7 @@ async function pushCommand(options) {
 }
 
 module.exports = pushCommand;
+module.exports.compareFiles = compareFiles;
+module.exports.displayChanges = displayChanges;
+module.exports.formatFileDiff = formatFileDiff;
+module.exports.pushToRemote = pushToRemote;

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const utils = require('../utils');
 const {
   getCursorDir,
   ensureCache,
@@ -9,11 +10,10 @@ const {
   getProjectSpecificFiles,
   getProjectSpecificPattern,
   filterFilesByIgnore,
-  getRemoteDiffPaths,
   getCacheDir,
   createOutput,
   createLoader
-} = require('../utils');
+} = utils;
 
 async function getStatus() {
   const cursorDir = getCursorDir();
@@ -70,7 +70,7 @@ async function getStatus() {
   }
 
   const cacheDir = getCacheDir();
-  const remoteDiffPaths = await getRemoteDiffPaths(cacheDir);
+  const remoteDiffPaths = await utils.getRemoteDiffPaths(cacheDir);
   const remoteDiffSet = new Set(remoteDiffPaths.map((p) => p.replace(/\\/g, '/')));
 
   const trulySynced = [];

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -1,19 +1,17 @@
 const fsPromises = require('fs').promises;
 const path = require('path');
+const utils = require('../utils');
 const {
   getCursorDir,
-  ensureCache,
   getProjectSpecificFiles,
   getProjectSpecificPattern,
-  pathExists,
   ensureDir,
-  getIgnoreList,
   isPathIgnored,
   createOutput,
   createLoader
-} = require('../utils');
+} = utils;
 const { getActiveConfig } = require('../config');
-const { getStatus } = require('./status');
+const statusMod = require('./status');
 
 async function backupProjectSpecific(projectSpecific, targetDir) {
   const backup = {};
@@ -23,7 +21,7 @@ async function backupProjectSpecific(projectSpecific, targetDir) {
     const files = projectSpecific[dir] || [];
     for (const file of files) {
       const src = path.join(targetDir, dir, file);
-      if (pathExists(src)) {
+      if (utils.pathExists(src)) {
         backup[`${dir}/${file}`] = await fsPromises.readFile(src, 'utf8');
       }
     }
@@ -34,7 +32,7 @@ async function backupProjectSpecific(projectSpecific, targetDir) {
 
 async function copyDir(src, dest, excludePattern, sourceRoot = null, ignoreList = null) {
   await ensureDir(dest);
-  const list = ignoreList || getIgnoreList();
+  const list = ignoreList || utils.getIgnoreList();
 
   const entries = await fsPromises.readdir(src, { withFileTypes: true });
   const root = sourceRoot || src;
@@ -78,17 +76,17 @@ async function syncCommand(options) {
     const projectSpecific = getProjectSpecificFiles(cursorDir);
     const backup = await backupProjectSpecific(projectSpecific, cursorDir);
 
-    const sourceCursorDir = await ensureCache(verbose, {
+    const sourceCursorDir = await utils.ensureCache(verbose, {
       skipPull: options.noCacheUpdate || false
     });
 
-    if (!pathExists(sourceCursorDir)) {
+    if (!utils.pathExists(sourceCursorDir)) {
       const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
       throw new Error(`Source directory '${sourcePath}' not found in repository`);
     }
 
     if (!dryRun) {
-      const status = await getStatus();
+      const status = await statusMod.getStatus();
       if (status.modified.length > 0 && !options.force) {
         const err = new Error(
           `Cannot pull: ${status.modified.length} locally modified file(s) would be overwritten. Use --force to rewrite.`

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -144,3 +144,4 @@ async function runTUI() {
 }
 
 module.exports = runTUI;
+module.exports.runAction = runAction;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -19,10 +19,453 @@
         "crules": "bin/crules.js"
       },
       "devDependencies": {
-        "prettier": "^3.8.1"
+        "prettier": "^3.8.1",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/external-editor": {
@@ -44,6 +487,503 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/ansi-escapes": {
@@ -83,6 +1023,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -161,6 +1111,33 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -182,6 +1159,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -252,6 +1239,34 @@
         "node": ">=16"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -279,6 +1294,55 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -286,6 +1350,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/figures": {
@@ -301,6 +1403,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -497,6 +1614,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -517,6 +1641,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mimic-fn": {
@@ -555,11 +1696,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -711,6 +1878,72 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
@@ -752,6 +1985,51 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-async": {
@@ -798,11 +2076,42 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.1",
@@ -851,6 +2160,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -868,6 +2190,67 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -893,6 +2276,177 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -900,6 +2454,23 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crules-cli",
-  "version": "1.1.15",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crules-cli",
-      "version": "1.1.15",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.15",
+  "version": "1.2.0",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {
@@ -8,9 +8,10 @@
   },
   "scripts": {
     "install-global": "npm install -g .",
-    "test": "node --test test/config.test.js test/version-check.test.js",
-    "format": "prettier --write \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\"",
-    "format:check": "prettier --check \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\""
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "format": "prettier --write \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\" \"vitest.config.mjs\"",
+    "format:check": "prettier --check \"bin/**/*.js\" \"lib/**/*.js\" \"test/**/*.js\" \"vitest.config.mjs\""
   },
   "keywords": [
     "cursor",
@@ -52,6 +53,7 @@
     "ora": "^9.3.0"
   },
   "devDependencies": {
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/test/config-command.test.js
+++ b/test/config-command.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'node:module';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cfgcmd-home-'));
+const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cfgcmd-proj-'));
+
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const prevCwd = process.cwd();
+process.chdir(tmpProject);
+
+function wipeConfig() {
+  const cliDir = path.join(tmpHome, '.crules-cli');
+  if (fs.existsSync(cliDir)) fs.rmSync(cliDir, { recursive: true, force: true });
+}
+
+function writeBaseConfig() {
+  fs.mkdirSync(path.join(tmpHome, '.crules-cli'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpHome, '.crules-cli', '.crules-cli-config.json'),
+    JSON.stringify(
+      {
+        active: 'default',
+        configs: {
+          default: {
+            repository: 'https://example.com/original.git',
+            cacheDir: path.join(tmpHome, '.crules-cli', 'default'),
+            ignoreList: [],
+            projectSpecificPattern: '^project-',
+            commitMessage: 'x',
+            sourcePath: '.cursor',
+            targetPath: '.cursor'
+          }
+        }
+      },
+      null,
+      2
+    )
+  );
+}
+
+function reloadConfigModules() {
+  delete require.cache[require.resolve('../lib/config.js')];
+  delete require.cache[require.resolve('../lib/commands/config.js')];
+  return {
+    config: require('../lib/config.js'),
+    configCommand: require('../lib/commands/config.js')
+  };
+}
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+});
+
+let config;
+let configCommand;
+
+beforeEach(() => {
+  wipeConfig();
+  writeBaseConfig();
+  ({ config, configCommand } = reloadConfigModules());
+});
+
+describe('configCommand', () => {
+  it('edit updates key via positional key and editValue option', async () => {
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await configCommand('edit', 'default', 'repository', {
+        quiet: true,
+        editValue: 'https://edited-positional.git'
+      });
+    } finally {
+      console.log = orig;
+    }
+    expect(config.getConfig('default').repository).toBe('https://edited-positional.git');
+    expect(logs.some((l) => l.includes('Updated'))).toBe(true);
+  });
+
+  it('edit updates key via --key and --value style options', async () => {
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await configCommand('edit', 'default', null, {
+        quiet: true,
+        key: 'repository',
+        value: 'https://edited-flags.git'
+      });
+    } finally {
+      console.log = orig;
+    }
+    expect(config.getConfig('default').repository).toBe('https://edited-flags.git');
+  });
+
+  it('set writes a config key on active profile', async () => {
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await configCommand('set', 'repository', 'https://via-set.git', { quiet: true });
+    } finally {
+      console.log = orig;
+    }
+    expect(config.getConfig('default').repository).toBe('https://via-set.git');
+    expect(logs.some((l) => l.includes('Set'))).toBe(true);
+  });
+
+  it('use fails for missing alias', async () => {
+    const errs = [];
+    const orig = console.error;
+    console.error = (...a) => errs.push(a.join(' '));
+    try {
+      await configCommand('use', 'does-not-exist', null, { quiet: true });
+    } finally {
+      console.error = orig;
+    }
+    expect(errs.some((e) => e.includes('Failed to switch'))).toBe(true);
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,10 +1,12 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { test, after, beforeEach } = require('node:test');
-const assert = require('node:assert/strict');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'node:module';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
 
 const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cli-home-'));
 const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-cli-proj-'));
@@ -16,7 +18,7 @@ process.chdir(tmpProject);
 
 const config = require('../lib/config.js');
 
-after(() => {
+afterAll(() => {
   process.chdir(prevCwd);
   fs.rmSync(tmpHome, { recursive: true, force: true });
   fs.rmSync(tmpProject, { recursive: true, force: true });
@@ -31,40 +33,44 @@ function wipeState() {
 
 beforeEach(() => wipeState());
 
-test('getActiveScope is global without local config file', () => {
-  assert.equal(config.getActiveScope(), 'global');
-});
+describe('config', () => {
+  it('getActiveScope is global without local config file', () => {
+    expect(config.getActiveScope()).toBe('global');
+  });
 
-test('getActiveScope is local when local file defines active', () => {
-  fs.writeFileSync(
-    path.join(tmpProject, '.crules-cli-config.json'),
-    JSON.stringify({
-      active: 'default',
-      configs: { default: { repository: 'https://example.com/a.git' } }
-    })
-  );
-  assert.equal(config.getActiveScope(), 'local');
-});
+  it('getActiveScope is local when local file defines active', () => {
+    fs.writeFileSync(
+      path.join(tmpProject, '.crules-cli-config.json'),
+      JSON.stringify({
+        active: 'default',
+        configs: { default: { repository: 'https://example.com/a.git' } }
+      })
+    );
+    expect(config.getActiveScope()).toBe('local');
+  });
 
-test('setActiveConfig global clears active from local file', () => {
-  config.createConfig('proj', { repository: 'https://example.com/r.git' }, false);
-  fs.writeFileSync(
-    path.join(tmpProject, '.crules-cli-config.json'),
-    JSON.stringify({ active: 'default', configs: {} })
-  );
-  assert.equal(config.getActiveScope(), 'local');
-  config.setActiveConfig('proj', false);
-  assert.equal(config.getActiveScope(), 'global');
-  const raw = JSON.parse(fs.readFileSync(path.join(tmpProject, '.crules-cli-config.json'), 'utf8'));
-  assert.equal(Object.prototype.hasOwnProperty.call(raw, 'active'), false);
-});
+  it('setActiveConfig global clears active from local file', () => {
+    config.createConfig('proj', { repository: 'https://example.com/r.git' }, false);
+    fs.writeFileSync(
+      path.join(tmpProject, '.crules-cli-config.json'),
+      JSON.stringify({ active: 'default', configs: {} })
+    );
+    expect(config.getActiveScope()).toBe('local');
+    config.setActiveConfig('proj', false);
+    expect(config.getActiveScope()).toBe('global');
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(tmpProject, '.crules-cli-config.json'), 'utf8')
+    );
+    expect(Object.prototype.hasOwnProperty.call(raw, 'active')).toBe(false);
+  });
 
-test('loadGlobalOnlyConfigs does not include profiles only in local file', () => {
-  config.createConfig('gonly', { repository: 'https://g.test/repo.git' }, false);
-  config.createConfig('lonly', { repository: 'https://l.test/repo.git' }, true);
-  const g = config.loadGlobalOnlyConfigs();
-  assert.ok(g.configs.gonly);
-  assert.equal(g.configs.lonly, undefined);
-  const merged = config.getAllConfigs();
-  assert.ok(merged.configs.lonly);
+  it('loadGlobalOnlyConfigs does not include profiles only in local file', () => {
+    config.createConfig('gonly', { repository: 'https://g.test/repo.git' }, false);
+    config.createConfig('lonly', { repository: 'https://l.test/repo.git' }, true);
+    const g = config.loadGlobalOnlyConfigs();
+    expect(g.configs.gonly).toBeTruthy();
+    expect(g.configs.lonly).toBeUndefined();
+    const merged = config.getAllConfigs();
+    expect(merged.configs.lonly).toBeTruthy();
+  });
 });

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+import path from 'path';
+import { createRequire } from 'node:module';
+import crypto from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+function isUnder(p, segment) {
+  return path.normalize(p).replace(/\\/g, '/').includes(segment);
+}
+
+const utils = require('../lib/utils.js');
+const diffCommand = require('../lib/commands/diff.js');
+
+function md5(s) {
+  return crypto
+    .createHash('md5')
+    .update(s || '')
+    .digest('hex');
+}
+
+beforeEach(() => {
+  vi.spyOn(utils, 'ensureCache').mockResolvedValue(undefined);
+  vi.spyOn(utils, 'getCursorDir').mockReturnValue('/proj/.cursor');
+  vi.spyOn(utils, 'getCursorSourceDir').mockReturnValue('/cache/.cursor');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('diffCommand', () => {
+  it('throws when file path is missing', async () => {
+    await expect(diffCommand('', { quiet: true })).rejects.toThrow('File path is required');
+  });
+
+  it('throws when neither project nor source has the file', async () => {
+    vi.spyOn(utils, 'getFileContent').mockResolvedValue(null);
+    await expect(diffCommand('rules/missing.mdc', { quiet: true })).rejects.toThrow(
+      'File not found: rules/missing.mdc'
+    );
+  });
+
+  it('prints source-only as deleted in project', async () => {
+    const lines = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+    vi.spyOn(utils, 'getFileContent').mockImplementation(async (p) => {
+      if (isUnder(p, 'cache')) return 'only-remote';
+      return null;
+    });
+    try {
+      await diffCommand('rules/x.mdc', { quiet: false });
+    } finally {
+      vi.mocked(console.log).mockRestore();
+    }
+    expect(lines.some((l) => l.includes('deleted in project'))).toBe(true);
+    expect(lines.some((l) => l.includes('only-remote'))).toBe(true);
+  });
+
+  it('prints project-only as new file', async () => {
+    const lines = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+    vi.spyOn(utils, 'getFileContent').mockImplementation(async (p) => {
+      if (isUnder(p, 'proj')) return 'only-local';
+      return null;
+    });
+    try {
+      await diffCommand('rules/y.mdc', { quiet: false });
+    } finally {
+      vi.mocked(console.log).mockRestore();
+    }
+    expect(lines.some((l) => l.includes('new file'))).toBe(true);
+    expect(lines.some((l) => l.includes('only-local'))).toBe(true);
+  });
+
+  it('reports identical when hashes match', async () => {
+    const lines = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+    vi.spyOn(utils, 'getFileContent').mockResolvedValue('same');
+    vi.spyOn(utils, 'getFileHash').mockImplementation(async (c) => md5(c));
+    try {
+      await diffCommand('rules/z.mdc', { quiet: false });
+    } finally {
+      vi.mocked(console.log).mockRestore();
+    }
+    expect(lines.some((l) => l.includes('identical'))).toBe(true);
+  });
+
+  it('prints diff hunks when content differs', async () => {
+    const lines = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+    vi.spyOn(utils, 'getFileContent').mockImplementation(async (p) => {
+      if (isUnder(p, 'proj')) return 'B';
+      return 'A';
+    });
+    vi.spyOn(utils, 'getFileHash').mockImplementation(async (c) => md5(c));
+    try {
+      await diffCommand('rules/diff.mdc', { quiet: false });
+    } finally {
+      vi.mocked(console.log).mockRestore();
+    }
+    const big = lines.join('\n');
+    expect(big).toMatch(/-|\+/);
+    expect(big).toContain('(line) - source removed');
+  });
+
+  it('verbose includes context lines in diff output', async () => {
+    const lines = [];
+    vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+    vi.spyOn(utils, 'getFileContent').mockImplementation(async (p) => {
+      if (isUnder(p, 'proj')) return 'line2\nline3';
+      return 'line1\nline2\nline3';
+    });
+    vi.spyOn(utils, 'getFileHash').mockImplementation(async (c) => md5(c));
+    try {
+      await diffCommand('rules/ctx.mdc', { quiet: false, verbose: true });
+    } finally {
+      vi.mocked(console.log).mockRestore();
+    }
+    const joined = lines.join('\n');
+    expect(joined).toMatch(/\d+\s+line2/);
+  });
+});

--- a/test/ignore.test.js
+++ b/test/ignore.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'node:module';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-ignore-home-'));
+const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-ignore-proj-'));
+
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const prevCwd = process.cwd();
+process.chdir(tmpProject);
+
+function wipeConfig() {
+  const cliDir = path.join(tmpHome, '.crules-cli');
+  if (fs.existsSync(cliDir)) fs.rmSync(cliDir, { recursive: true, force: true });
+}
+
+function writeBaseConfig() {
+  fs.mkdirSync(path.join(tmpHome, '.crules-cli'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpHome, '.crules-cli', '.crules-cli-config.json'),
+    JSON.stringify(
+      {
+        active: 'default',
+        configs: {
+          default: {
+            repository: 'https://example.com/r.git',
+            cacheDir: path.join(tmpHome, '.crules-cli', 'default'),
+            ignoreList: [],
+            projectSpecificPattern: '^project-',
+            commitMessage: 'x',
+            sourcePath: '.cursor',
+            targetPath: '.cursor'
+          },
+          extra: {
+            repository: 'https://example.com/e.git',
+            cacheDir: path.join(tmpHome, '.crules-cli', 'extra'),
+            ignoreList: [],
+            projectSpecificPattern: '^project-',
+            commitMessage: 'x',
+            sourcePath: '.cursor',
+            targetPath: '.cursor'
+          }
+        }
+      },
+      null,
+      2
+    )
+  );
+}
+
+function reloadModules() {
+  delete require.cache[require.resolve('../lib/config.js')];
+  delete require.cache[require.resolve('../lib/commands/ignore.js')];
+  return {
+    config: require('../lib/config.js'),
+    ignoreCommand: require('../lib/commands/ignore.js')
+  };
+}
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+});
+
+let config;
+let ignoreCommand;
+
+beforeEach(() => {
+  wipeConfig();
+  writeBaseConfig();
+  ({ config, ignoreCommand } = reloadModules());
+});
+
+describe('ignoreCommand', () => {
+  it('throws when alias does not exist', async () => {
+    await expect(ignoreCommand('list', undefined, { quiet: true, alias: 'nope' })).rejects.toThrow(
+      "Config 'nope' does not exist"
+    );
+  });
+
+  it('add then list persists ignoreList on active config', async () => {
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await ignoreCommand('add', '*.bak', { quiet: true });
+      await ignoreCommand('list', undefined, { quiet: true });
+    } finally {
+      console.log = orig;
+    }
+    expect(logs.some((l) => l.includes('*.bak'))).toBe(true);
+    const c = config.getConfig(config.getActiveConfigName());
+    expect(c.ignoreList).toContain('*.bak');
+  });
+
+  it('warns when adding duplicate pattern', async () => {
+    await ignoreCommand('add', 'dup.mdc', { quiet: true });
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await ignoreCommand('add', 'dup.mdc', { quiet: true });
+    } finally {
+      console.log = orig;
+    }
+    expect(logs.some((l) => l.includes('already in the ignore'))).toBe(true);
+  });
+
+  it('remove missing pattern logs warning', async () => {
+    const logs = [];
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await ignoreCommand('remove', 'not-there', { quiet: true });
+    } finally {
+      console.log = orig;
+    }
+    expect(logs.some((l) => l.includes('not in the ignore'))).toBe(true);
+  });
+
+  it('throws on unknown action', async () => {
+    await expect(ignoreCommand('nope', 'x', { quiet: true })).rejects.toThrow(/Unknown action/);
+  });
+
+  it('throws when add without pattern', async () => {
+    await expect(ignoreCommand('add', '', { quiet: true })).rejects.toThrow(
+      /Pattern or file path is required/
+    );
+  });
+});

--- a/test/push.test.js
+++ b/test/push.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+import { createRequire } from 'node:module';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const utils = require('../lib/utils.js');
+const { pushToRemote, displayChanges, formatFileDiff } = require('../lib/commands/push.js');
+
+beforeEach(() => {
+  vi.spyOn(utils, 'execAsync').mockResolvedValue({ stdout: '', stderr: '' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('displayChanges', () => {
+  it('returns false when no added, modified, or deleted', () => {
+    const logs = [];
+    const r = displayChanges({ added: [], modified: [], deleted: [], unchanged: [] }, (m) =>
+      logs.push(m)
+    );
+    expect(r).toBe(false);
+    expect(logs.some((l) => String(l).includes('No changes'))).toBe(true);
+  });
+
+  it('returns true when there are changes', () => {
+    const r = displayChanges(
+      { added: [{ path: 'a.mdc' }], modified: [], deleted: [], unchanged: [] },
+      () => {}
+    );
+    expect(r).toBe(true);
+  });
+});
+
+describe('formatFileDiff', () => {
+  it('returns line markers for simple line diff', () => {
+    const { lines, summary } = formatFileDiff('a\n', 'b\n');
+    expect(summary).toMatch(/removed|added/);
+    expect(lines.some((l) => l.includes('-'))).toBe(true);
+    expect(lines.some((l) => l.includes('+'))).toBe(true);
+  });
+});
+
+describe('pushToRemote', () => {
+  it('succeeds on first git push', async () => {
+    await pushToRemote('/cache', {});
+    expect(utils.execAsync).toHaveBeenCalledWith('git push', { cwd: '/cache' });
+  });
+
+  it('retries with upstream when no upstream branch', async () => {
+    utils.execAsync
+      .mockRejectedValueOnce(Object.assign(new Error('fail'), { stderr: 'no upstream branch' }))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+    await pushToRemote('/cache', {});
+    expect(utils.execAsync).toHaveBeenCalledTimes(2);
+    expect(utils.execAsync).toHaveBeenLastCalledWith('git push -u origin HEAD', { cwd: '/cache' });
+  });
+
+  it('throws with suggestions when non-fast-forward and noPull', async () => {
+    utils.execAsync.mockRejectedValue(
+      Object.assign(new Error('fail'), { stderr: 'Updates were rejected (non-fast-forward)' })
+    );
+    await expect(pushToRemote('/cache', { noPull: true })).rejects.toMatchObject({
+      message: expect.stringContaining('Remote has changes'),
+      suggestions: expect.arrayContaining([expect.stringContaining('crules pull')])
+    });
+  });
+
+  it('pull --rebase then push on non-fast-forward', async () => {
+    utils.execAsync
+      .mockRejectedValueOnce(Object.assign(new Error('fail'), { stderr: 'Updates were rejected' }))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+    await pushToRemote('/cache', { noPull: false, quiet: true });
+    expect(utils.execAsync).toHaveBeenCalledWith('git pull --rebase', { cwd: '/cache' });
+    expect(utils.execAsync).toHaveBeenLastCalledWith('git push', { cwd: '/cache' });
+  });
+
+  it('throws createError on rebase conflict', async () => {
+    utils.execAsync
+      .mockRejectedValueOnce(Object.assign(new Error('fail'), { stderr: 'non-fast-forward' }))
+      .mockRejectedValueOnce(
+        Object.assign(new Error('pull fail'), { stderr: 'CONFLICT (content)' })
+      );
+    await expect(pushToRemote('/cache', { quiet: true })).rejects.toMatchObject({
+      message: expect.stringContaining('Merge conflict'),
+      suggestions: expect.arrayContaining([expect.stringContaining('Cache directory')])
+    });
+  });
+
+  it('rethrows unrelated push errors', async () => {
+    const err = Object.assign(new Error('network down'), { stderr: 'fatal: unable' });
+    utils.execAsync.mockRejectedValue(err);
+    await expect(pushToRemote('/cache', {})).rejects.toThrow('network down');
+  });
+});

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'node:module';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-status-home-'));
+const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-status-proj-'));
+const tmpCache = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-status-cache-'));
+
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+fs.mkdirSync(path.join(tmpHome, '.crules-cli'), { recursive: true });
+fs.writeFileSync(
+  path.join(tmpHome, '.crules-cli', '.crules-cli-config.json'),
+  JSON.stringify(
+    {
+      active: 'default',
+      configs: {
+        default: {
+          repository: 'https://example.com/crules-fixture.git',
+          cacheDir: tmpCache,
+          sourcePath: '.cursor',
+          targetPath: '.cursor',
+          projectSpecificPattern: '^project-',
+          commitMessage: 'Update cursor rules: {summary}',
+          ignoreList: []
+        }
+      }
+    },
+    null,
+    2
+  )
+);
+
+const prevCwd = process.cwd();
+process.chdir(tmpProject);
+
+const utils = require('../lib/utils.js');
+const { getStatus } = require('../lib/commands/status.js');
+
+const projCursor = path.join(tmpProject, '.cursor');
+const cacheCursor = path.join(tmpCache, '.cursor');
+
+function wipeCursorTrees() {
+  for (const root of [projCursor, cacheCursor]) {
+    if (fs.existsSync(root)) fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writeFile(p, content) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf8');
+}
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+  fs.rmSync(tmpCache, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  wipeCursorTrees();
+  vi.spyOn(utils, 'getRemoteDiffPaths').mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** getStatus uses path.relative; on Windows rel paths use backslashes. */
+function norm(p) {
+  return p.replace(/\\/g, '/');
+}
+
+describe('getStatus', () => {
+  it('classifies file only in project as added', async () => {
+    writeFile(path.join(projCursor, 'rules/new.mdc'), 'only here');
+
+    const s = await getStatus();
+    expect(s.added.map(norm)).toContain('rules/new.mdc');
+    expect(s.modified).toHaveLength(0);
+    expect(s.deleted).toHaveLength(0);
+    expect(s.synced).toHaveLength(0);
+    expect(s.outdated).toHaveLength(0);
+  });
+
+  it('classifies file only in source cache as deleted', async () => {
+    writeFile(path.join(cacheCursor, 'rules/gone.mdc'), 'remote only');
+
+    const s = await getStatus();
+    expect(s.deleted.map(norm)).toContain('rules/gone.mdc');
+    expect(s.added).toHaveLength(0);
+  });
+
+  it('classifies hash mismatch as modified', async () => {
+    writeFile(path.join(projCursor, 'rules/x.mdc'), 'local');
+    writeFile(path.join(cacheCursor, 'rules/x.mdc'), 'remote');
+
+    const s = await getStatus();
+    expect(s.modified.map(norm)).toContain('rules/x.mdc');
+    expect(s.synced).toHaveLength(0);
+  });
+
+  it('classifies matching content as synced when not in remote diff', async () => {
+    writeFile(path.join(projCursor, 'rules/same.mdc'), 'identical');
+    writeFile(path.join(cacheCursor, 'rules/same.mdc'), 'identical');
+
+    const s = await getStatus();
+    expect(s.synced.map(norm)).toContain('rules/same.mdc');
+    expect(s.outdated).toHaveLength(0);
+  });
+
+  it('moves synced file to outdated when path is in remote diff', async () => {
+    writeFile(path.join(projCursor, 'rules/same.mdc'), 'identical');
+    writeFile(path.join(cacheCursor, 'rules/same.mdc'), 'identical');
+    utils.getRemoteDiffPaths.mockResolvedValue(['rules/same.mdc']);
+
+    const s = await getStatus();
+    expect(s.outdated.map(norm)).toContain('rules/same.mdc');
+    expect(s.synced).toHaveLength(0);
+  });
+
+  it('normalizes backslashes in remote diff paths', async () => {
+    writeFile(path.join(projCursor, 'rules/same.mdc'), 'identical');
+    writeFile(path.join(cacheCursor, 'rules/same.mdc'), 'identical');
+    utils.getRemoteDiffPaths.mockResolvedValue(['rules\\same.mdc']);
+
+    const s = await getStatus();
+    expect(s.outdated.map(norm)).toContain('rules/same.mdc');
+  });
+
+  it('skips project-specific basename pattern', async () => {
+    writeFile(path.join(projCursor, 'rules/project-local.mdc'), 'x');
+    writeFile(path.join(projCursor, 'rules/normal.mdc'), 'a');
+    writeFile(path.join(cacheCursor, 'rules/normal.mdc'), 'b');
+
+    const s = await getStatus();
+    expect(s.added).not.toContain('rules/project-local.mdc');
+    expect(s.modified).not.toContain('rules/project-local.mdc');
+    expect(s.modified.map(norm)).toContain('rules/normal.mdc');
+  });
+});

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'node:module';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-sync-home-'));
+const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-sync-proj-'));
+
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+fs.mkdirSync(path.join(tmpHome, '.crules-cli'), { recursive: true });
+fs.writeFileSync(
+  path.join(tmpHome, '.crules-cli', '.crules-cli-config.json'),
+  JSON.stringify(
+    {
+      active: 'default',
+      configs: {
+        default: {
+          repository: 'https://example.com/crules-sync.git',
+          cacheDir: path.join(tmpHome, '.crules-cli', 'default'),
+          sourcePath: '.cursor',
+          targetPath: '.cursor',
+          projectSpecificPattern: '^project-',
+          commitMessage: 'x',
+          ignoreList: []
+        }
+      }
+    },
+    null,
+    2
+  )
+);
+
+const prevCwd = process.cwd();
+process.chdir(tmpProject);
+
+const utils = require('../lib/utils.js');
+const statusMod = require('../lib/commands/status.js');
+const syncCommand = require('../lib/commands/sync.js');
+
+const emptyProjectSpecific = {
+  rules: [],
+  commands: [],
+  docs: [],
+  skills: [],
+  agents: [],
+  hooks: []
+};
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.spyOn(utils, 'getCursorDir').mockReturnValue(path.join(tmpProject, '.cursor'));
+  vi.spyOn(utils, 'getProjectSpecificFiles').mockReturnValue(emptyProjectSpecific);
+  vi.spyOn(utils, 'ensureCache').mockResolvedValue(path.join(tmpProject, 'cache-src', '.cursor'));
+  vi.spyOn(utils, 'pathExists').mockReturnValue(true);
+  vi.spyOn(utils, 'getProjectSpecificPattern').mockReturnValue(/^project-/);
+  vi.spyOn(statusMod, 'getStatus').mockResolvedValue({
+    added: [],
+    modified: [],
+    deleted: [],
+    outdated: [],
+    synced: []
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('syncCommand (pull)', () => {
+  it('dry run does not call getStatus and returns after messaging', async () => {
+    const spy = vi.spyOn(statusMod, 'getStatus');
+    await syncCommand({ dryRun: true, quiet: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('throws when source cursor dir is missing in cache', async () => {
+    utils.pathExists.mockImplementation((p) => {
+      if (String(p).includes('cache-src')) return false;
+      return true;
+    });
+    await expect(syncCommand({ quiet: true })).rejects.toThrow(
+      /Source directory '\.cursor' not found/
+    );
+  });
+
+  it('throws with suggestions when local modified files and no force', async () => {
+    statusMod.getStatus.mockResolvedValue({
+      added: [],
+      modified: ['rules/x.mdc'],
+      deleted: [],
+      outdated: [],
+      synced: []
+    });
+    await expect(syncCommand({ quiet: true })).rejects.toMatchObject({
+      message: expect.stringContaining('Cannot pull'),
+      suggestions: ['crules pull --force']
+    });
+  });
+
+  it('does not throw for modified check when force is true', async () => {
+    statusMod.getStatus.mockResolvedValue({
+      added: [],
+      modified: ['rules/x.mdc'],
+      deleted: [],
+      outdated: [],
+      synced: []
+    });
+    const srcRoot = path.join(tmpProject, 'cache-src', '.cursor');
+    const destRoot = path.join(tmpProject, '.cursor');
+    fs.mkdirSync(path.join(srcRoot, 'rules'), { recursive: true });
+    fs.writeFileSync(path.join(srcRoot, 'rules', 'a.mdc'), 'x', 'utf8');
+    fs.mkdirSync(path.join(destRoot, 'rules'), { recursive: true });
+
+    await syncCommand({ quiet: true, force: true });
+    expect(fs.existsSync(path.join(destRoot, 'rules', 'a.mdc'))).toBe(true);
+  });
+});

--- a/test/tui.test.js
+++ b/test/tui.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+describe('tui', () => {
+  it('exports runTUI as default and runAction for tests / tooling', () => {
+    const tui = require('../lib/commands/tui.js');
+    expect(typeof tui).toBe('function');
+    expect(typeof tui.runAction).toBe('function');
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const utils = require('../lib/utils.js');
+
+describe('createError', () => {
+  it('attaches suggestions array', () => {
+    const err = utils.createError('msg', ['a', 'b']);
+    expect(err.message).toBe('msg');
+    expect(err.suggestions).toEqual(['a', 'b']);
+  });
+});
+
+describe('isPathIgnored', () => {
+  it('returns false for empty list', () => {
+    expect(utils.isPathIgnored('rules/foo.mdc', [])).toBe(false);
+    expect(utils.isPathIgnored('rules/foo.mdc', null)).toBe(false);
+  });
+
+  it('matches glob patterns', () => {
+    expect(utils.isPathIgnored('rules/draft-x.mdc', ['**/draft-*'])).toBe(true);
+    expect(utils.isPathIgnored('rules/prod.mdc', ['**/draft-*'])).toBe(false);
+  });
+
+  it('normalizes backslashes', () => {
+    expect(utils.isPathIgnored('rules\\x.mdc', ['rules/x.mdc'])).toBe(true);
+  });
+});
+
+describe('filterFilesByIgnore', () => {
+  it('returns all files when ignore list empty via explicit []', () => {
+    const files = { 'a.mdc': '/a', 'b.tmp': '/b' };
+    expect(utils.filterFilesByIgnore(files, [])).toEqual(files);
+  });
+
+  it('drops ignored paths for explicit ignore list', () => {
+    const files = { 'a.mdc': '/a', 'x.tmp': '/b' };
+    const out = utils.filterFilesByIgnore(files, ['*.tmp']);
+    expect(out).toEqual({ 'a.mdc': '/a' });
+  });
+});

--- a/test/version-check.test.js
+++ b/test/version-check.test.js
@@ -1,12 +1,16 @@
 'use strict';
 
-const { test } = require('node:test');
-const assert = require('node:assert/strict');
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
 const { compareSemverGreater } = require('../lib/version-check.js');
 
-test('compareSemverGreater', () => {
-  assert.equal(compareSemverGreater('1.2.0', '1.1.9'), true);
-  assert.equal(compareSemverGreater('1.1.9', '1.2.0'), false);
-  assert.equal(compareSemverGreater('1.0.0', '1.0.0'), false);
-  assert.equal(compareSemverGreater('2.0.0', '1.99.99'), true);
+describe('version-check', () => {
+  it('compareSemverGreater', () => {
+    expect(compareSemverGreater('1.2.0', '1.1.9')).toBe(true);
+    expect(compareSemverGreater('1.1.9', '1.2.0')).toBe(false);
+    expect(compareSemverGreater('1.0.0', '1.0.0')).toBe(false);
+    expect(compareSemverGreater('2.0.0', '1.99.99')).toBe(true);
+  });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.js'],
+    pool: 'forks'
+  }
+});


### PR DESCRIPTION
## Summary

Adds a Vitest-based unit suite across pull/push/status/diff/config/ignore/utils/TUI, refactors command code so shared `utils` calls are spy-friendly, fixes `config edit` so Commander options reach the handler, and ships **1.2.0** with updated contributor docs and changelog.

## Active Changes

- **Vitest** (`vitest.config.mjs`, `npm test` / `npm run test:watch`); `config.test.js` and `version-check` tests aligned with Vitest
- New specs: `status`, `push`, `sync` (pull), `diff`, `config` command dispatch, `ignore`, `utils`, minimal `tui` export smoke
- Commands use `utils.*` module paths where tests need stubs (`execAsync`, `getRemoteDiffPaths`, cache/path helpers); `tui` exports `runAction`
- **Fix:** `crules config edit` forwards CLI `options` (fourth argument) correctly
- **Docs:** CONTRIBUTING test matrix + CI note; README Node 20+ and dev test pointer; CHANGELOG **[1.2.0]**; CI step label “Run Vitest”
- **Version:** `1.2.0` (`package.json` / lockfile)

## Database Changes

None (CLI only; no database).

## Environment Variables

None new.

## Testing

- `npm ci`; `npm run format:check`; `npm test` (Vitest, ~49 tests)
- Manual spot-check: `crules config edit <alias> <key> <value>` with flags if you use that path

## Technical Details

Minor **patch-level** behavior fix for `config edit` with options; semver **minor** bump for broader test/tooling and contributor-facing docs.