### PR TITLE
chore: harden release workflow npm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,24 @@ jobs:
           fi
 
       # Trusted publishing requires Node >= 22.14 and npm CLI >= 11.5.1 (see npm docs).
+      # Use Node 24.x: it bundles npm 11.x. Avoid `npm install -g npm@…` — that can corrupt
+      # the global npm on runners (e.g. MODULE_NOT_FOUND: promise-retry).
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
-      - name: Ensure npm 11.5.1+ (trusted publishing)
-        run: npm install -g npm@^11.5.1
+      - name: Verify npm >= 11.5.1 (trusted publishing)
+        run: |
+          set -e
+          NPM_VER=$(npm --version)
+          echo "npm version: $NPM_VER"
+          node -e "
+            const v = process.argv[1].split(/[.-]/).map(Number);
+            const ok = v[0] > 11 || (v[0] === 11 && (v[1] > 5 || (v[1] === 5 && (v[2] || 0) >= 1)));
+            if (!ok) { console.error('npm must be >= 11.5.1 for trusted publishing, got ' + process.argv[1]); process.exit(1); }
+          " "$NPM_VER"
 
       - name: Install dependencies (npm ci)
         run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Save. npm does not validate this until the next publish—double-check spelling.
 
 1. Bump `version` in `package.json` (and `package-lock.json` root version) and commit.
 2. Create and push a tag matching that version, e.g. `v1.2.3` for `package.json` `1.2.3`. The tag must point at the **same commit** as the bump — npm uses `package.json`, not the tag name; the workflow fails if they disagree.
-3. The **Release** workflow runs on `v*` tags: it publishes to npm with OIDC, then creates a **GitHub Release** for that tag (auto-generated release notes). If `npm publish` fails, no release is created.
+3. The **Release** workflow runs on `v*` tags (Node **24.x**, bundled **npm 11.5.1+** — no global `npm install -g npm`, which can break on runners). It publishes to npm with OIDC, then creates a **GitHub Release** for that tag (auto-generated release notes). If `npm publish` fails, no release is created.
 
 Optional hardening after a successful publish: package **Settings** → **Publishing access** → restrict token-based publishes (“disallow tokens” / require 2FA) so only trusted publishing can ship releases.
 


### PR DESCRIPTION
- switch release job to Node 24.x so bundled npm satisfies trusted publishing requirements
- replace global npm install with explicit npm version guard and document the rationale in contributing guide