### PR TITLE
chore: release v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.2] - 2026-04-21
+
+### Fixed
+
+- `crules config create` now prompts for alias when missing, then continues interactive setup without hanging behind a loader spinner.
+- `crules` interactive menu now supports both `inquirer.prompt` and `inquirer.default.prompt`, preventing startup crashes on newer inquirer export shapes.
+- project-specific matching now correctly handles nested paths (such as `skills/project-*/SKILL.md`) and avoids `EISDIR` failures during pull backups.
+
+---
+
 ## [1.2.1] - 2026-04-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.4] - 2026-04-21
+
+### Fixed
+
+- Updated TUI prompts to use `select` with Inquirer v13, so menu options render correctly instead of showing only prompt text.
+- Improved config and ignore navigation so Back returns to the previous menu level, and dead-end actions now offer consistent Back/Exit choices.
+- Centralized TUI navigation labels/values for Back/Exit into shared constants to simplify future updates.
+
+---
+
+## [1.2.3] - 2026-04-21
+
+### Fixed
+
+- `crules` no-argument startup now lazy-loads TUI, so prompt module issues no longer block non-TUI commands like `--version`, `status`, `pull`, or `push`.
+- Added a bin-level smoke test that validates `bin/crules.js --version` works without entering interactive prompt flow.
+- `crules config create` now retries alias input until valid, supports `cancel`, and rejects existing aliases in both direct and interactive flows.
+
+---
+
 ## [1.2.2] - 2026-04-21
 
 ### Fixed

--- a/bin/crules.js
+++ b/bin/crules.js
@@ -8,7 +8,6 @@ const statusCommand = require('../lib/commands/status');
 const diffCommand = require('../lib/commands/diff');
 const configCommand = require('../lib/commands/config');
 const ignoreCommand = require('../lib/commands/ignore');
-const runTUI = require('../lib/commands/tui');
 const { maybePrintUpdateNotice } = require('../lib/version-check');
 
 const program = new Command();
@@ -138,6 +137,7 @@ const skipUpdateNotice =
   if (args.length === 0) {
     await maybePrintUpdateNotice({ quiet: false });
     try {
+      const runTUI = require('../lib/commands/tui');
       await runTUI();
     } catch (err) {
       console.error(err.message || err);

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -183,10 +183,14 @@ async function configUseCommand(alias, options) {
 
 async function configCreateCommand(alias, options) {
   if (!alias) {
-    console.error('\n❌ Alias is required');
-    console.log('Usage: crules config create <alias>');
-    console.log('Example: crules config create shopify-theme');
-    return;
+    alias = await promptUser('Enter config alias: ');
+    if (!alias || alias.trim() === '') {
+      console.error('\n❌ Alias is required');
+      console.log('Usage: crules config create <alias>');
+      console.log('Example: crules config create shopify-theme');
+      return;
+    }
+    alias = alias.trim();
   }
 
   if (!isValidAlias(alias)) {
@@ -339,7 +343,17 @@ async function configRenameCommand(oldAlias, newAlias, options) {
 }
 
 async function configCommand(action, key, value, options) {
-  const loader = createLoader('Updating config...', options.quiet);
+  const mayPrompt =
+    (action === 'create' && (!key || !options.repository)) ||
+    (action === 'set' && !value) ||
+    (action === 'edit' &&
+      !(
+        (options && (options.editValue || options.value)) ||
+        (options && options.key && value) ||
+        value
+      )) ||
+    action === 'delete';
+  const loader = mayPrompt ? null : createLoader('Updating config...', options.quiet);
   try {
     if (action === 'list') {
       await configListCommand(options);

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -201,6 +201,10 @@ async function configCreateCommand(alias, options) {
         );
         continue;
       }
+      if (getConfig(trimmedAlias)) {
+        console.error(`\n❌ Config '${trimmedAlias}' already exists`);
+        continue;
+      }
       alias = trimmedAlias;
     }
   }
@@ -210,6 +214,11 @@ async function configCreateCommand(alias, options) {
     console.log(
       'Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
     );
+    return;
+  }
+
+  if (getConfig(alias)) {
+    console.error(`\n❌ Config '${alias}' already exists`);
     return;
   }
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -183,14 +183,26 @@ async function configUseCommand(alias, options) {
 
 async function configCreateCommand(alias, options) {
   if (!alias) {
-    alias = await promptUser('Enter config alias: ');
-    if (!alias || alias.trim() === '') {
-      console.error('\n❌ Alias is required');
-      console.log('Usage: crules config create <alias>');
-      console.log('Example: crules config create shopify-theme');
-      return;
+    while (!alias) {
+      const enteredAlias = await promptUser('Enter config alias (or type "cancel"): ');
+      if (!enteredAlias || enteredAlias.trim() === '') {
+        console.error('\n❌ Alias is required');
+        continue;
+      }
+      const trimmedAlias = enteredAlias.trim();
+      if (trimmedAlias.toLowerCase() === 'cancel') {
+        console.log('\n❌ Create cancelled.');
+        return;
+      }
+      if (!isValidAlias(trimmedAlias)) {
+        console.error('\n❌ Invalid alias');
+        console.log(
+          'Alias must start with a letter and contain only alphanumeric characters, hyphens, and underscores.'
+        );
+        continue;
+      }
+      alias = trimmedAlias;
     }
-    alias = alias.trim();
   }
 
   if (!isValidAlias(alias)) {

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -13,6 +13,7 @@ const {
   getCursorSourceDir,
   getProjectSpecificFiles,
   getProjectSpecificPattern,
+  isProjectSpecificPath,
   ensureDir,
   getCacheDir,
   ensureGitIdentity,
@@ -41,8 +42,7 @@ async function compareFiles() {
   const pattern = getProjectSpecificPattern();
 
   for (const [relPath, projectPath] of Object.entries(projectFiles)) {
-    const fileName = path.basename(relPath);
-    if (pattern.test(fileName)) {
+    if (isProjectSpecificPath(relPath, pattern)) {
       continue;
     }
 
@@ -64,8 +64,7 @@ async function compareFiles() {
   }
 
   for (const [relPath] of Object.entries(sourceFiles)) {
-    const fileName = path.basename(relPath);
-    if (pattern.test(fileName)) {
+    if (isProjectSpecificPath(relPath, pattern)) {
       continue;
     }
 

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -9,6 +9,7 @@ const {
   getCursorSourceDir,
   getProjectSpecificFiles,
   getProjectSpecificPattern,
+  isProjectSpecificPath,
   filterFilesByIgnore,
   getCacheDir,
   createOutput,
@@ -34,8 +35,7 @@ async function getStatus() {
   const pattern = getProjectSpecificPattern();
 
   for (const [relPath, projectPath] of Object.entries(projectFiles)) {
-    const fileName = path.basename(relPath);
-    if (pattern.test(fileName)) {
+    if (isProjectSpecificPath(relPath, pattern)) {
       continue;
     }
 
@@ -57,8 +57,7 @@ async function getStatus() {
   }
 
   for (const [relPath] of Object.entries(sourceFiles)) {
-    const fileName = path.basename(relPath);
-    if (pattern.test(fileName)) {
+    if (isProjectSpecificPath(relPath, pattern)) {
       continue;
     }
 

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -5,6 +5,7 @@ const {
   getCursorDir,
   getProjectSpecificFiles,
   getProjectSpecificPattern,
+  isProjectSpecificPath,
   ensureDir,
   isPathIgnored,
   createOutput,
@@ -41,14 +42,14 @@ async function copyDir(src, dest, excludePattern, sourceRoot = null, ignoreList 
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
 
-    if (excludePattern && entry.name.match(excludePattern)) {
+    const relPath = path.relative(root, srcPath).replace(/\\/g, '/');
+    if (excludePattern && isProjectSpecificPath(relPath, excludePattern)) {
       continue;
     }
 
     if (entry.isDirectory()) {
       await copyDir(srcPath, destPath, excludePattern, root, list);
     } else {
-      const relPath = path.relative(root, srcPath).replace(/\\/g, '/');
       if (list.length > 0 && isPathIgnored(relPath, list)) continue;
       await fsPromises.copyFile(srcPath, destPath);
     }

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -1,9 +1,9 @@
 const inquirer = require('inquirer');
 const promptFactory =
   inquirer.default && typeof inquirer.default.createPromptModule === 'function'
-      ? inquirer.default.createPromptModule
-      : typeof inquirer.createPromptModule === 'function'
-        ? inquirer.createPromptModule
+    ? inquirer.default.createPromptModule
+    : typeof inquirer.createPromptModule === 'function'
+      ? inquirer.createPromptModule
       : null;
 
 const prompt =
@@ -52,10 +52,7 @@ function buildBackChoice() {
 }
 
 function buildBackExitChoices() {
-  return [
-    buildBackChoice(),
-    { name: NAV_LABELS.EXIT, value: NAV_VALUES.EXIT }
-  ];
+  return [buildBackChoice(), { name: NAV_LABELS.EXIT, value: NAV_VALUES.EXIT }];
 }
 
 async function promptBackOrExit() {

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -1,10 +1,18 @@
 const inquirer = require('inquirer');
-const prompt =
-  typeof inquirer.prompt === 'function'
-    ? inquirer.prompt.bind(inquirer)
-    : inquirer.default && typeof inquirer.default.prompt === 'function'
-      ? inquirer.default.prompt.bind(inquirer.default)
+const promptFactory =
+  inquirer.default && typeof inquirer.default.createPromptModule === 'function'
+      ? inquirer.default.createPromptModule
+      : typeof inquirer.createPromptModule === 'function'
+        ? inquirer.createPromptModule
       : null;
+
+const prompt =
+  promptFactory?.() ||
+  (typeof inquirer.prompt === 'function'
+    ? inquirer.prompt
+    : inquirer.default && typeof inquirer.default.prompt === 'function'
+      ? inquirer.default.prompt
+      : null);
 
 if (!prompt) {
   throw new Error('Inquirer prompt API not available');
@@ -17,6 +25,16 @@ const configCommand = require('./config');
 const ignoreCommand = require('./ignore');
 const { ensureCache } = require('../utils');
 
+const NAV_VALUES = {
+  BACK: 'back',
+  EXIT: 'exit'
+};
+
+const NAV_LABELS = {
+  BACK: 'Back',
+  EXIT: 'Exit'
+};
+
 const CHOICES = {
   pull: { name: 'Pull - Get latest from repository', value: 'pull' },
   push: { name: 'Push - Push local changes', value: 'push' },
@@ -24,22 +42,48 @@ const CHOICES = {
   diff: { name: 'Diff - View diff for a file', value: 'diff' },
   config: { name: 'Config - Manage configuration', value: 'config' },
   ignore: { name: 'Ignore - Manage ignore list', value: 'ignore' },
-  exit: { name: 'Exit', value: 'exit' }
+  exit: { name: NAV_LABELS.EXIT, value: NAV_VALUES.EXIT }
 };
 
 const baseOptions = { quiet: false };
+
+function buildBackChoice() {
+  return { name: NAV_LABELS.BACK, value: NAV_VALUES.BACK };
+}
+
+function buildBackExitChoices() {
+  return [
+    buildBackChoice(),
+    { name: NAV_LABELS.EXIT, value: NAV_VALUES.EXIT }
+  ];
+}
+
+async function promptBackOrExit() {
+  const { next } = await prompt([
+    {
+      type: 'select',
+      name: 'next',
+      message: 'What next?',
+      choices: buildBackExitChoices()
+    }
+  ]);
+  return next;
+}
 
 async function runAction(choice) {
   switch (choice) {
     case 'pull':
       await syncCommand({ ...baseOptions });
-      break;
+      if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
+      return;
     case 'push':
       await pushCommand({ ...baseOptions, force: false });
-      break;
+      if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
+      return;
     case 'status':
       await statusCommand(baseOptions);
-      break;
+      if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
+      return;
     case 'diff': {
       const { filePath } = await prompt([
         {
@@ -50,63 +94,111 @@ async function runAction(choice) {
         }
       ]);
       await diffCommand(filePath.trim(), baseOptions);
-      break;
+      if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
+      return;
     }
     case 'config': {
-      const { action } = await prompt([
-        {
-          type: 'list',
-          name: 'action',
-          message: 'Config action:',
-          choices: [
-            { name: 'List configs', value: 'list' },
-            { name: 'Get setting', value: 'get' },
-            { name: 'Set setting', value: 'set' },
-            { name: 'Use config (switch alias)', value: 'use' },
-            { name: 'Back', value: 'back' }
-          ]
-        }
-      ]);
-      if (action === 'back') return;
-      let key, value;
-      if (action !== 'list') {
-        const keyPrompt = await prompt([
-          { type: 'input', name: 'key', message: action === 'use' ? 'Alias:' : 'Key:' }
+      while (true) {
+        const { scope } = await prompt([
+          {
+            type: 'select',
+            name: 'scope',
+            message: 'Config scope:',
+            choices: [
+              { name: 'Global config', value: 'global' },
+              { name: 'Local config (.crules-cli-config.json)', value: 'local' },
+              buildBackChoice()
+            ]
+          }
         ]);
-        key = keyPrompt.key?.trim();
-        if (action === 'set' && key) {
-          const valPrompt = await prompt([{ type: 'input', name: 'value', message: 'Value:' }]);
-          value = valPrompt.value;
+        if (scope === NAV_VALUES.BACK) return;
+        const local = scope === 'local';
+
+        while (true) {
+          const { action } = await prompt([
+            {
+              type: 'select',
+              name: 'action',
+              message: 'Config action:',
+              choices: [
+                { name: 'List configs', value: 'list' },
+                { name: 'Get setting', value: 'get' },
+                { name: 'Set setting', value: 'set' },
+                { name: 'Create config', value: 'create' },
+                { name: 'Use config (switch alias)', value: 'use' },
+                buildBackChoice()
+              ]
+            }
+          ]);
+          if (action === NAV_VALUES.BACK) break;
+          let key, value;
+          if (action !== 'list') {
+            const keyPrompt = await prompt([
+              {
+                type: 'input',
+                name: 'key',
+                message:
+                  action === 'use' || action === 'create'
+                    ? 'Alias:'
+                    : action === 'set'
+                      ? 'Key:'
+                      : 'Key (leave blank for full config):'
+              }
+            ]);
+            key = keyPrompt.key?.trim();
+            if (action === 'set' && key) {
+              const valPrompt = await prompt([{ type: 'input', name: 'value', message: 'Value:' }]);
+              value = valPrompt.value;
+            } else if (action === 'create' && key) {
+              const repoPrompt = await prompt([
+                {
+                  type: 'input',
+                  name: 'value',
+                  message: 'Repository URL (optional):'
+                }
+              ]);
+              value = repoPrompt.value?.trim() || null;
+            }
+          }
+          const configOptions = { local };
+          if (action === 'create' && value) {
+            configOptions.repository = value;
+          }
+          await configCommand(action, key, value, configOptions);
+          if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
         }
       }
-      await configCommand(action, key, value, {});
-      break;
+      return;
     }
     case 'ignore': {
-      const { action } = await prompt([
-        {
-          type: 'list',
-          name: 'action',
-          message: 'Ignore action:',
-          choices: [
-            { name: 'List', value: 'list' },
-            { name: 'Add pattern', value: 'add' },
-            { name: 'Remove pattern', value: 'remove' },
-            { name: 'Back', value: 'back' }
-          ]
+      while (true) {
+        const { action } = await prompt([
+          {
+            type: 'select',
+            name: 'action',
+            message: 'Ignore action:',
+            choices: [
+              { name: 'List', value: 'list' },
+              { name: 'Add pattern', value: 'add' },
+              { name: 'Remove pattern', value: 'remove' },
+              buildBackChoice()
+            ]
+          }
+        ]);
+        if (action === NAV_VALUES.BACK) return;
+        let pattern;
+        if (action !== 'list') {
+          const p = await prompt([{ type: 'input', name: 'pattern', message: 'Pattern or path:' }]);
+          pattern = p.pattern?.trim();
         }
-      ]);
-      if (action === 'back') return;
-      let pattern;
-      if (action !== 'list') {
-        const p = await prompt([{ type: 'input', name: 'pattern', message: 'Pattern or path:' }]);
-        pattern = p.pattern?.trim();
+        await ignoreCommand(action, pattern, {});
+        if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
       }
-      await ignoreCommand(action, pattern, {});
-      break;
     }
     case 'exit':
       process.exit(0);
+    default:
+      return { skipBackPrompt: false };
   }
 }
 
@@ -118,35 +210,26 @@ async function runTUI() {
     process.exit(1);
   }
 
-  const { choice } = await prompt([
-    {
-      type: 'list',
-      name: 'choice',
-      message: 'What would you like to do?',
-      choices: Object.values(CHOICES)
+  while (true) {
+    const { choice } = await prompt([
+      {
+        type: 'select',
+        name: 'choice',
+        message: 'What would you like to do?',
+        choices: Object.values(CHOICES)
+      }
+    ]);
+
+    if (choice === NAV_VALUES.EXIT) {
+      process.exit(0);
     }
-  ]);
 
-  if (choice === 'exit') {
-    process.exit(0);
-  }
-
-  try {
-    await runAction(choice);
-  } catch (err) {
-    // Error already displayed by command (loader.fail + suggestions)
-  }
-
-  // Loop back to menu
-  const { again } = await prompt([
-    {
-      type: 'confirm',
-      name: 'again',
-      message: 'Back to menu?',
-      default: true
+    try {
+      await runAction(choice);
+    } catch (err) {
+      // Error already displayed by command (loader.fail + suggestions)
     }
-  ]);
-  if (again) await runTUI();
+  }
 }
 
 module.exports = runTUI;

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -1,4 +1,14 @@
 const inquirer = require('inquirer');
+const prompt =
+  typeof inquirer.prompt === 'function'
+    ? inquirer.prompt.bind(inquirer)
+    : inquirer.default && typeof inquirer.default.prompt === 'function'
+      ? inquirer.default.prompt.bind(inquirer.default)
+      : null;
+
+if (!prompt) {
+  throw new Error('Inquirer prompt API not available');
+}
 const syncCommand = require('./sync');
 const pushCommand = require('./push');
 const statusCommand = require('./status');
@@ -31,7 +41,7 @@ async function runAction(choice) {
       await statusCommand(baseOptions);
       break;
     case 'diff': {
-      const { filePath } = await inquirer.prompt([
+      const { filePath } = await prompt([
         {
           type: 'input',
           name: 'filePath',
@@ -43,7 +53,7 @@ async function runAction(choice) {
       break;
     }
     case 'config': {
-      const { action } = await inquirer.prompt([
+      const { action } = await prompt([
         {
           type: 'list',
           name: 'action',
@@ -60,12 +70,12 @@ async function runAction(choice) {
       if (action === 'back') return;
       let key, value;
       if (action !== 'list') {
-        const keyPrompt = await inquirer.prompt([
+        const keyPrompt = await prompt([
           { type: 'input', name: 'key', message: action === 'use' ? 'Alias:' : 'Key:' }
         ]);
         key = keyPrompt.key?.trim();
         if (action === 'set' && key) {
-          const valPrompt = await inquirer.prompt([
+          const valPrompt = await prompt([
             { type: 'input', name: 'value', message: 'Value:' }
           ]);
           value = valPrompt.value;
@@ -75,7 +85,7 @@ async function runAction(choice) {
       break;
     }
     case 'ignore': {
-      const { action } = await inquirer.prompt([
+      const { action } = await prompt([
         {
           type: 'list',
           name: 'action',
@@ -91,7 +101,7 @@ async function runAction(choice) {
       if (action === 'back') return;
       let pattern;
       if (action !== 'list') {
-        const p = await inquirer.prompt([
+        const p = await prompt([
           { type: 'input', name: 'pattern', message: 'Pattern or path:' }
         ]);
         pattern = p.pattern?.trim();
@@ -112,7 +122,7 @@ async function runTUI() {
     process.exit(1);
   }
 
-  const { choice } = await inquirer.prompt([
+  const { choice } = await prompt([
     {
       type: 'list',
       name: 'choice',
@@ -132,7 +142,7 @@ async function runTUI() {
   }
 
   // Loop back to menu
-  const { again } = await inquirer.prompt([
+  const { again } = await prompt([
     {
       type: 'confirm',
       name: 'again',

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -75,9 +75,7 @@ async function runAction(choice) {
         ]);
         key = keyPrompt.key?.trim();
         if (action === 'set' && key) {
-          const valPrompt = await prompt([
-            { type: 'input', name: 'value', message: 'Value:' }
-          ]);
+          const valPrompt = await prompt([{ type: 'input', name: 'value', message: 'Value:' }]);
           value = valPrompt.value;
         }
       }
@@ -101,9 +99,7 @@ async function runAction(choice) {
       if (action === 'back') return;
       let pattern;
       if (action !== 'list') {
-        const p = await prompt([
-          { type: 'input', name: 'pattern', message: 'Pattern or path:' }
-        ]);
+        const p = await prompt([{ type: 'input', name: 'pattern', message: 'Pattern or path:' }]);
         pattern = p.pattern?.trim();
       }
       await ignoreCommand(action, pattern, {});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,6 +35,22 @@ function getProjectSpecificPattern() {
   }
 }
 
+function patternMatches(value, pattern) {
+  if (!pattern) return false;
+  pattern.lastIndex = 0;
+  return pattern.test(value);
+}
+
+function isProjectSpecificPath(relPath, pattern = getProjectSpecificPattern()) {
+  const normalizedPath = String(relPath || '').replace(/\\/g, '/');
+  const segments = normalizedPath.split('/').filter(Boolean);
+  const fileName = path.basename(normalizedPath);
+
+  if (patternMatches(normalizedPath, pattern)) return true;
+  if (patternMatches(fileName, pattern)) return true;
+  return segments.some((segment) => patternMatches(segment, pattern));
+}
+
 function getIgnoreList() {
   const list = getActiveConfig().ignoreList;
   return Array.isArray(list) ? list : [];
@@ -135,13 +151,31 @@ function getProjectSpecificFiles(targetDir) {
   for (const { key, ext } of dirs) {
     const dirPath = path.join(targetDir, key);
     if (!pathExists(dirPath)) continue;
-    const files = fs.readdirSync(dirPath);
-    projectSpecific[key] = files.filter(
-      (file) => pattern.test(file) && (!ext || file.endsWith(ext))
+    const allFiles = Object.keys(getAllFilesSync(dirPath, dirPath));
+    projectSpecific[key] = allFiles.filter(
+      (file) => isProjectSpecificPath(file, pattern) && (!ext || file.endsWith(ext))
     );
   }
 
   return projectSpecific;
+}
+
+function getAllFilesSync(dir, baseDir = dir) {
+  const files = {};
+  if (!pathExists(dir)) return files;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.relative(baseDir, fullPath);
+    if (entry.isDirectory()) {
+      Object.assign(files, getAllFilesSync(fullPath, baseDir));
+    } else {
+      files[relPath] = fullPath;
+    }
+  }
+
+  return files;
 }
 
 async function getAllFiles(dir, baseDir = dir) {
@@ -381,6 +415,7 @@ module.exports = {
   getCacheDir,
   getCursorSourceDir,
   getProjectSpecificPattern,
+  isProjectSpecificPath,
   getIgnoreList,
   isPathIgnored,
   filterFilesByIgnore,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/test/config-command.test.js
+++ b/test/config-command.test.js
@@ -48,6 +48,12 @@ function writeBaseConfig() {
 }
 
 function reloadConfigModules() {
+  const utilsPath = require.resolve('../lib/utils.js');
+  delete require.cache[utilsPath];
+  const utils = require(utilsPath);
+  if (global.__testPromptUser) {
+    utils.promptUser = global.__testPromptUser;
+  }
   delete require.cache[require.resolve('../lib/config.js')];
   delete require.cache[require.resolve('../lib/commands/config.js')];
   return {
@@ -66,6 +72,7 @@ let config;
 let configCommand;
 
 beforeEach(() => {
+  global.__testPromptUser = null;
   wipeConfig();
   writeBaseConfig();
   ({ config, configCommand } = reloadConfigModules());
@@ -127,5 +134,27 @@ describe('configCommand', () => {
       console.error = orig;
     }
     expect(errs.some((e) => e.includes('Failed to switch'))).toBe(true);
+  });
+
+  it('create interactive loop retries invalid alias then accepts valid one', async () => {
+    const prompts = ['1bad', 'shopify-theme'];
+    global.__testPromptUser = async () => prompts.shift() || '';
+    ({ config, configCommand } = reloadConfigModules());
+
+    await configCommand('create', null, null, {
+      quiet: true,
+      repository: 'https://example.com/new.git'
+    });
+
+    expect(config.getConfig('shopify-theme')).toMatchObject({
+      repository: 'https://example.com/new.git'
+    });
+  });
+
+  it('create interactive loop can cancel', async () => {
+    global.__testPromptUser = async () => 'cancel';
+    ({ config, configCommand } = reloadConfigModules());
+    await configCommand('create', null, null, { quiet: true, repository: 'x' });
+    expect(config.getConfig('cancel')).toBe(null);
   });
 });

--- a/test/config-command.test.js
+++ b/test/config-command.test.js
@@ -160,7 +160,7 @@ describe('configCommand', () => {
     } finally {
       console.error = origErr;
     }
-    expect(errs.some((e) => e.includes("already exists"))).toBe(true);
+    expect(errs.some((e) => e.includes('already exists'))).toBe(true);
   });
 
   it('create interactive loop retries duplicate alias then accepts valid one', async () => {

--- a/test/config-command.test.js
+++ b/test/config-command.test.js
@@ -151,6 +151,26 @@ describe('configCommand', () => {
     });
   });
 
+  it('create rejects duplicate alias passed directly', async () => {
+    const errs = [];
+    const origErr = console.error;
+    console.error = (...a) => errs.push(a.join(' '));
+    try {
+      await configCommand('create', 'default', null, { quiet: true });
+    } finally {
+      console.error = origErr;
+    }
+    expect(errs.some((e) => e.includes("already exists"))).toBe(true);
+  });
+
+  it('create interactive loop retries duplicate alias then accepts valid one', async () => {
+    const prompts = ['default', 'shopify-theme'];
+    global.__testPromptUser = async () => prompts.shift() || '';
+    ({ config, configCommand } = reloadConfigModules());
+    await configCommand('create', null, null, { quiet: true, repository: 'x' });
+    expect(config.getConfig('shopify-theme')).toMatchObject({ repository: 'x' });
+  });
+
   it('create interactive loop can cancel', async () => {
     global.__testPromptUser = async () => 'cancel';
     ({ config, configCommand } = reloadConfigModules());

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -136,13 +136,15 @@ describe('getStatus', () => {
     expect(s.outdated.map(norm)).toContain('rules/same.mdc');
   });
 
-  it('skips project-specific basename pattern', async () => {
+  it('skips project-specific files by basename and path segment', async () => {
     writeFile(path.join(projCursor, 'rules/project-local.mdc'), 'x');
+    writeFile(path.join(projCursor, 'skills/project-local/SKILL.md'), 'x');
     writeFile(path.join(projCursor, 'rules/normal.mdc'), 'a');
     writeFile(path.join(cacheCursor, 'rules/normal.mdc'), 'b');
 
     const s = await getStatus();
     expect(s.added).not.toContain('rules/project-local.mdc');
+    expect(s.added).not.toContain('skills/project-local/SKILL.md');
     expect(s.modified).not.toContain('rules/project-local.mdc');
     expect(s.modified.map(norm)).toContain('rules/normal.mdc');
   });

--- a/test/tui.test.js
+++ b/test/tui.test.js
@@ -1,11 +1,22 @@
 'use strict';
 
+import { spawnSync } from 'child_process';
+import path from 'path';
 import { createRequire } from 'node:module';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
 describe('tui', () => {
+  it('bin can execute non-tui command paths without loading prompt flow', () => {
+    const binPath = path.join(process.cwd(), 'bin', 'crules.js');
+    const result = spawnSync(process.execPath, [binPath, '--version'], {
+      encoding: 'utf8'
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
   it('exports runTUI as default and runAction for tests / tooling', () => {
     const tui = require('../lib/commands/tui.js');
     expect(typeof tui).toBe('function');

--- a/test/tui.test.js
+++ b/test/tui.test.js
@@ -3,9 +3,16 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 import { createRequire } from 'node:module';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const require = createRequire(import.meta.url);
+const inquirerPath = require.resolve('inquirer');
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  delete require.cache[inquirerPath];
+  delete require.cache[require.resolve('../lib/commands/tui.js')];
+});
 
 describe('tui', () => {
   it('bin can execute non-tui command paths without loading prompt flow', () => {
@@ -21,5 +28,29 @@ describe('tui', () => {
     const tui = require('../lib/commands/tui.js');
     expect(typeof tui).toBe('function');
     expect(typeof tui.runAction).toBe('function');
+  });
+
+  it('prefers default.createPromptModule when both exist', () => {
+    const sentinelPrompt = async () => ({});
+    require.cache[inquirerPath] = {
+      exports: {
+        createPromptModule: () => {
+          throw new Error('root createPromptModule should not be used');
+        },
+        default: {
+          createPromptModule: () => sentinelPrompt
+        }
+      }
+    };
+
+    const tui = require('../lib/commands/tui.js');
+    expect(typeof tui).toBe('function');
+  });
+
+  it('uses select prompts instead of removed list alias', () => {
+    const tuiPath = require.resolve('../lib/commands/tui.js');
+    const source = require('fs').readFileSync(tuiPath, 'utf8');
+    expect(source.includes("type: 'list'")).toBe(false);
+    expect(source.includes("type: 'select'")).toBe(true);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 import { createRequire } from 'node:module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
@@ -41,5 +44,30 @@ describe('filterFilesByIgnore', () => {
     const files = { 'a.mdc': '/a', 'x.tmp': '/b' };
     const out = utils.filterFilesByIgnore(files, ['*.tmp']);
     expect(out).toEqual({ 'a.mdc': '/a' });
+  });
+});
+
+describe('getProjectSpecificFiles', () => {
+  it('collects only files, including nested skill paths', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'crules-utils-'));
+    const cursorDir = path.join(root, '.cursor');
+    fs.mkdirSync(path.join(cursorDir, 'skills', 'project-bump-version'), { recursive: true });
+    fs.mkdirSync(path.join(cursorDir, 'skills', 'project-empty'), { recursive: true });
+    fs.mkdirSync(path.join(cursorDir, 'rules'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cursorDir, 'skills', 'project-bump-version', 'SKILL.md'),
+      'content',
+      'utf8'
+    );
+    fs.writeFileSync(path.join(cursorDir, 'rules', 'project-local.mdc'), 'x', 'utf8');
+
+    const out = utils.getProjectSpecificFiles(cursorDir);
+    const normalizedSkills = out.skills.map((p) => p.replace(/\\/g, '/'));
+    const normalizedRules = out.rules.map((p) => p.replace(/\\/g, '/'));
+    expect(normalizedSkills).toContain('project-bump-version/SKILL.md');
+    expect(normalizedSkills).not.toContain('project-empty');
+    expect(normalizedRules).toContain('project-local.mdc');
+
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Release v1.2.4

This PR prepares the package for version 1.2.4 release.

## Summary
This release stabilizes the CLI TUI and config flows after the previous releases by fixing broken menu rendering, tightening back-navigation behavior, and improving interactive config creation validation. It also updates release metadata for v1.2.4.

## Active Changes
- fixed Inquirer v13 TUI compatibility so interactive choices render correctly in menus.
- fixed no-arg CLI behavior by lazy-loading TUI only when needed, preventing TUI import issues from affecting non-TUI commands.
- improved TUI navigation so Back consistently returns to the previous menu level.
- added dedicated Back/Exit handling for dead-end actions instead of forcing generic menu confirmations.
- improved `config create` UX with retry/cancel behavior and duplicate alias checks.
- updated tests covering TUI behavior and config interactive flows.

## Testing
- validated focused Vitest coverage for `test/tui.test.js` and `test/config-command.test.js`.
- manually verified TUI menu flow and back-navigation behavior through nested config/ignore paths.

## Technical Details
- related issue: fixes around TUI prompt rendering and navigation regressions introduced during Inquirer v13 migration.