### PR TITLE
chore: release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.6] - 2026-04-21
+
+### Changed
+
+- Cache model now uses alias folder mirrors for selected `sourcePath` contents, with hidden `.crules-git` metadata kept inside each alias cache directory.
+- Push/status/sync flows now operate against hidden git metadata while keeping project-facing cache folders clean.
+- README cache structure docs now include nested `skills/.../SKILL.md` examples aligned with the new cache model.
+
+### Fixed
+
+- Pull/sync now explicitly excludes `.crules-git` from copied project files, including regression coverage to prevent metadata leakage.
+- On Windows, `.crules-git` now gets hidden attribute assignment as best-effort behavior.
+
+---
+
 ## [1.2.5] - 2026-04-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.5] - 2026-04-21
+
+### Fixed
+
+- `ensureCache()` retry path now reuses a shared cache-sync routine instead of duplicating fetch/reset/clean logic.
+- TUI `pull` now offers a two-step force confirmation flow when local modified files block a normal pull.
+- TUI config menu now includes "View current config settings" and supports global/local scope from the menu.
+
+### Changed
+
+- Interactive command docs now reflect the current TUI ordering, back-navigation semantics, and force flow behavior.
+
+---
+
 ## [1.2.4] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ crules
 - **Exit** – Quit
 
 Navigation notes:
+
 - Back always returns to the previous menu level.
 - Dead-end actions show `Back` / `Exit` choices in TUI.
 - Pull in TUI now offers a force-retry flow when local changes would be overwritten.
@@ -147,15 +148,15 @@ crules pull
 crules pull --verbose
 crules pull --force         # Overwrite local changes
 crules pull --dry-run       # Preview what would change
-crules pull --no-cache-update  # Use cached repo without fetching
+crules pull --no-cache-update  # Use existing alias cache mirror
 crules pull -q              # Quiet mode for scripts
 ```
 
 **What it does:**
 
 - Fails if you have locally modified files (use `--force` to overwrite)
-- Updates the cached repository (unless `--no-cache-update`)
-- Copies `.cursor` folder to your project
+- Updates alias cache metadata and mirror contents (unless `--no-cache-update`)
+- Copies mirrored `sourcePath` contents into your project `targetPath`
 - Preserves project-specific files (files matching the configured pattern)
 - Respects ignore list (excluded files are not copied)
 
@@ -379,7 +380,7 @@ You can create multiple config profiles with aliases to manage different cursor 
 - **Default config**: No alias required, always available
 - **Named configs**: Must have an alias (e.g., `shopify-theme`, `react`, `shopify-app`)
 - **Active config**: The currently selected config used by pull/push/status/diff commands
-- **Cache isolation**: Each config has its own cache directory
+- **Cache isolation**: Each config has its own cache directory mirror
 
 **Example workflow:**
 
@@ -440,14 +441,14 @@ my-plugin/
 
 Project-specific file preservation (files matching `projectSpecificPattern`) works for:
 
-| Folder | Purpose |
-|--------|---------|
-| `rules/` | Coding standards (.mdc files) |
-| `commands/` | Custom commands |
-| `docs/` | Documentation |
-| `skills/` | Agent skills (SKILL.md format) |
-| `agents/` | Specialized sub-agents |
-| `hooks/` | Event-driven automation |
+| Folder      | Purpose                        |
+| ----------- | ------------------------------ |
+| `rules/`    | Coding standards (.mdc files)  |
+| `commands/` | Custom commands                |
+| `docs/`     | Documentation                  |
+| `skills/`   | Agent skills (SKILL.md format) |
+| `agents/`   | Specialized sub-agents         |
+| `hooks/`    | Event-driven automation        |
 
 All folders are synced recursively. Project-specific files are preserved during pull and excluded from push.
 
@@ -456,11 +457,22 @@ All folders are synced recursively. Project-specific files are preserved during 
 **Config location:** `~/.crules-cli/.crules-cli-config.json`
 
 **Directory structure:**
+
 ```
 ~/.crules-cli/
 ├── .crules-cli-config.json   # All configs + active alias
-├── default/                  # Cache for default config
-└── {alias}/                  # Cache per named config (e.g. nextjs/)
+├── default/                  # Mirrored sourcePath contents for default config
+│   ├── .crules-git/          # Hidden git metadata/worktree used for push/status
+│   ├── skills/
+│   │   └── project-bump-version/
+│   │       └── SKILL.md      # Example mirrored skill file
+│   └── ...                   # Other mirrored files/folders
+└── {alias}/                  # Mirrored sourcePath contents for named config
+    ├── .crules-git/          # Hidden git metadata/worktree for this alias
+    ├── skills/
+    │   └── commit/
+    │       └── SKILL.md      # Example mirrored skill file
+    └── ...                   # Other mirrored files/folders
 ```
 
 **Config format:**
@@ -498,8 +510,8 @@ All folders are synced recursively. Project-specific files are preserved during 
 **Per-Config Options:**
 
 - **repository** (required): Git repository URL. Must be configured before using any commands.
-- **cacheDir**: Cache directory for this config. Defaults to `~/.crules-cli/{alias}`.
-- **sourcePath**: Path within the cached repo to sync from (default: `.cursor`). Use `.` or `` for plugin root.
+- **cacheDir**: Alias cache directory. It stores a mirror of selected `sourcePath` contents plus hidden `.crules-git` metadata. Defaults to `~/.crules-cli/{alias}`.
+- **sourcePath**: Path in the remote repository to mirror into `cacheDir` (default: `.cursor`). Use `.` for plugin root.
 - **targetPath**: Path in the project to sync to (default: `.cursor`). Use `.` for project root.
 - **projectSpecificPattern**: Regex pattern to identify project-specific files
 - **commitMessage**: Commit message template (use `{summary}` placeholder)

--- a/README.md
+++ b/README.md
@@ -109,15 +109,20 @@ Run without a subcommand to open an interactive menu:
 crules
 ```
 
+- **Status** – See what's different
 - **Pull** – Get latest from repository
 - **Push** – Push local changes
-- **Status** – See what's different
 - **Diff** – View diff for a file (prompts for path)
-- **Config** – List, get, set, or switch configs
+- **Config** – View current config, list/get/set, create, or switch configs (global/local scope)
 - **Ignore** – List, add, or remove ignore patterns
 - **Exit** – Quit
 
-After each action you can return to the menu. Use `crules -h` for non-interactive help.
+Navigation notes:
+- Back always returns to the previous menu level.
+- Dead-end actions show `Back` / `Exit` choices in TUI.
+- Pull in TUI now offers a force-retry flow when local changes would be overwritten.
+
+Use `crules -h` for non-interactive help.
 
 ### `crules pull`
 
@@ -133,7 +138,7 @@ crules pull [options]
 - `-q, --quiet` - Suppress non-error output
 - `-f, --force` - Overwrite locally modified files
 - `--dry-run` - Preview changes without applying them
-- `--no-cache-update` - Skip git pull in cache, use existing cache only
+- `--no-cache-update` - Skip cache fetch/reset sync, use existing cache only
 
 **Examples:**
 

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -16,6 +16,7 @@ const {
   isProjectSpecificPath,
   ensureDir,
   getCacheDir,
+  getCacheGitDir,
   ensureGitIdentity,
   createError,
   filterFilesByIgnore,
@@ -246,9 +247,10 @@ async function pushToRemote(cacheDir, options = {}) {
 
 async function pushChanges(changes, options) {
   const out = createOutput(options.quiet);
-  const sourceDir = getCursorSourceDir();
-  const cursorDir = getCursorDir();
   const cacheDir = getCacheDir();
+  const gitDir = getCacheGitDir(cacheDir);
+  const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
+  const sourceDir = sourcePath && sourcePath !== '.' ? path.join(gitDir, sourcePath) : gitDir;
 
   if (options.dryRun) {
     out('\n🔍 Dry run mode - no changes will be pushed\n');
@@ -278,28 +280,27 @@ async function pushChanges(changes, options) {
     }
   }
 
-  const gitStatus = await getGitStatus(cacheDir);
+  const gitStatus = await getGitStatus(gitDir);
 
   if (gitStatus.length === 0) {
     out('\n✅ No changes to commit (files already match repository state)');
     return;
   }
 
-  await ensureGitIdentity(cacheDir, process.cwd());
+  await ensureGitIdentity(gitDir, process.cwd());
 
   out('\n📤 Committing changes...');
-  const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
   const gitAddPath = sourcePath || '.';
-  await utils.execAsync(`git add "${gitAddPath}"`, { cwd: cacheDir });
+  await utils.execAsync(`git add "${gitAddPath}"`, { cwd: gitDir });
 
   const config = getActiveConfig();
   const summary = `${changes.added.length} added, ${changes.modified.length} modified, ${changes.deleted.length} deleted`;
   const commitMessage = config.commitMessage.replace('{summary}', summary);
 
-  await utils.execAsync(`git commit -m "${commitMessage}"`, { cwd: cacheDir });
+  await utils.execAsync(`git commit -m "${commitMessage}"`, { cwd: gitDir });
 
   out('📤 Pushing to repository...');
-  await pushToRemote(cacheDir, { noPull: options.noPull, quiet: options.quiet });
+  await pushToRemote(gitDir, { noPull: options.noPull, quiet: options.quiet });
 
   out('\n✅ Changes pushed successfully!');
 }

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -39,6 +39,7 @@ async function copyDir(src, dest, excludePattern, sourceRoot = null, ignoreList 
   const root = sourceRoot || src;
 
   for (const entry of entries) {
+    if (entry.name === '.crules-git') continue;
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
 

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -82,10 +82,7 @@ async function promptForceOrBack() {
       type: 'select',
       name: 'next',
       message: 'Local changes would be overwritten.',
-      choices: [
-        { name: 'Force', value: 'force' },
-        buildBackChoice()
-      ]
+      choices: [{ name: 'Force', value: 'force' }, buildBackChoice()]
     }
   ]);
   return next;

--- a/lib/commands/tui.js
+++ b/lib/commands/tui.js
@@ -36,9 +36,9 @@ const NAV_LABELS = {
 };
 
 const CHOICES = {
+  status: { name: "Status - See what's different", value: 'status' },
   pull: { name: 'Pull - Get latest from repository', value: 'pull' },
   push: { name: 'Push - Push local changes', value: 'push' },
-  status: { name: "Status - See what's different", value: 'status' },
   diff: { name: 'Diff - View diff for a file', value: 'diff' },
   config: { name: 'Config - Manage configuration', value: 'config' },
   ignore: { name: 'Ignore - Manage ignore list', value: 'ignore' },
@@ -67,10 +67,59 @@ async function promptBackOrExit() {
   return next;
 }
 
+function isForcePullError(error) {
+  return (
+    error &&
+    typeof error.message === 'string' &&
+    error.message.includes('Cannot pull:') &&
+    error.message.includes('Use --force')
+  );
+}
+
+async function promptForceOrBack() {
+  const { next } = await prompt([
+    {
+      type: 'select',
+      name: 'next',
+      message: 'Local changes would be overwritten.',
+      choices: [
+        { name: 'Force', value: 'force' },
+        buildBackChoice()
+      ]
+    }
+  ]);
+  return next;
+}
+
+async function promptForceConfirm() {
+  const { confirmForce } = await prompt([
+    {
+      type: 'select',
+      name: 'confirmForce',
+      message: 'Are you sure? Local changes will be overwritten.',
+      choices: [
+        { name: 'Yes', value: true },
+        { name: 'No', value: false }
+      ],
+      default: true
+    }
+  ]);
+  return confirmForce;
+}
+
 async function runAction(choice) {
   switch (choice) {
     case 'pull':
-      await syncCommand({ ...baseOptions });
+      try {
+        await syncCommand({ ...baseOptions });
+      } catch (error) {
+        if (!isForcePullError(error)) throw error;
+        const forceChoice = await promptForceOrBack();
+        if (forceChoice === NAV_VALUES.BACK) return;
+        const confirmed = await promptForceConfirm();
+        if (!confirmed) return;
+        await syncCommand({ ...baseOptions, force: true });
+      }
       if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
       return;
     case 'push':
@@ -118,6 +167,7 @@ async function runAction(choice) {
               name: 'action',
               message: 'Config action:',
               choices: [
+                { name: 'View current config settings', value: 'current' },
                 { name: 'List configs', value: 'list' },
                 { name: 'Get setting', value: 'get' },
                 { name: 'Set setting', value: 'set' },
@@ -129,6 +179,11 @@ async function runAction(choice) {
           ]);
           if (action === NAV_VALUES.BACK) break;
           let key, value;
+          if (action === 'current') {
+            await configCommand('get', null, null, { local });
+            if ((await promptBackOrExit()) === NAV_VALUES.EXIT) process.exit(0);
+            continue;
+          }
           if (action !== 'list') {
             const keyPrompt = await prompt([
               {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,18 +116,18 @@ async function ensureCache(verbose = false, options = {}) {
     }
   } else if (!skipPull) {
     if (verbose) console.log('🔄 Updating Cursor Rules repository...');
-    try {
+    const syncCache = async () => {
       await execAsync('git fetch origin', { cwd: cacheDir });
       const remoteRef = await getPreferredRemoteRef(cacheDir);
       await execAsync(`git reset --hard ${remoteRef}`, { cwd: cacheDir });
       await execAsync('git clean -fd', { cwd: cacheDir });
+    };
+    try {
+      await syncCache();
     } catch (error) {
-      if (verbose) console.log('⚠️  Pull failed, trying fetch...');
+      if (verbose) console.log('⚠️  Cache sync failed, retrying fetch/reset...');
       try {
-        await execAsync('git fetch origin', { cwd: cacheDir });
-        const remoteRef = await getPreferredRemoteRef(cacheDir);
-        await execAsync(`git reset --hard ${remoteRef}`, { cwd: cacheDir });
-        await execAsync('git clean -fd', { cwd: cacheDir });
+        await syncCache();
       } catch (fetchError) {
         throw new Error(
           `Failed to update repository: ${error.message}\nMake sure you have network access and git is properly configured.`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,10 +15,12 @@ function getCacheDir() {
   return getActiveConfig().cacheDir;
 }
 
+function getCacheGitDir(cacheDir = getCacheDir()) {
+  return path.join(cacheDir, '.crules-git');
+}
+
 function getSourceDir() {
-  const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
-  const p = sourcePath || '.';
-  return path.join(getCacheDir(), p);
+  return getCacheDir();
 }
 
 function getCursorSourceDir() {
@@ -103,12 +105,18 @@ async function ensureDir(dirPath) {
 async function ensureCache(verbose = false, options = {}) {
   const repoUrl = validateRepository();
   const cacheDir = getCacheDir();
+  const gitDir = getCacheGitDir(cacheDir);
+  const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
   const skipPull = options.skipPull || options.noCacheUpdate || false;
 
   if (!pathExists(cacheDir)) {
-    if (verbose) console.log('📦 Cloning Cursor Rules repository...');
+    await ensureDir(cacheDir);
+  }
+
+  if (!pathExists(gitDir)) {
+    if (verbose) console.log('📦 Cloning Cursor Rules repository metadata...');
     try {
-      await execAsync(`git clone ${repoUrl} "${cacheDir}"`);
+      await execAsync(`git clone ${repoUrl} "${gitDir}"`);
     } catch (error) {
       throw new Error(
         `Failed to clone repository: ${error.message}\nMake sure git is installed and the repository URL is correct.`
@@ -117,10 +125,10 @@ async function ensureCache(verbose = false, options = {}) {
   } else if (!skipPull) {
     if (verbose) console.log('🔄 Updating Cursor Rules repository...');
     const syncCache = async () => {
-      await execAsync('git fetch origin', { cwd: cacheDir });
-      const remoteRef = await getPreferredRemoteRef(cacheDir);
-      await execAsync(`git reset --hard ${remoteRef}`, { cwd: cacheDir });
-      await execAsync('git clean -fd', { cwd: cacheDir });
+      await execAsync('git fetch origin', { cwd: gitDir });
+      const remoteRef = await getPreferredRemoteRef(gitDir);
+      await execAsync(`git reset --hard ${remoteRef}`, { cwd: gitDir });
+      await execAsync('git clean -fd', { cwd: gitDir });
     };
     try {
       await syncCache();
@@ -135,7 +143,36 @@ async function ensureCache(verbose = false, options = {}) {
       }
     }
   }
+
+  const sourceRoot = sourcePath && sourcePath !== '.' ? path.join(gitDir, sourcePath) : gitDir;
+  if (!pathExists(sourceRoot)) {
+    throw new Error(`Source directory '${sourcePath}' not found in repository`);
+  }
+
+  await hydrateAliasCacheFromSource(cacheDir, gitDir, sourceRoot);
   return getCursorSourceDir();
+}
+
+async function hydrateAliasCacheFromSource(cacheDir, gitDir, sourceRoot) {
+  const entries = await fsPromises.readdir(cacheDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === path.basename(gitDir)) continue;
+    const fullPath = path.join(cacheDir, entry.name);
+    await fsPromises.rm(fullPath, { recursive: true, force: true });
+  }
+
+  const sourceEntries = await fsPromises.readdir(sourceRoot, { withFileTypes: true });
+  for (const entry of sourceEntries) {
+    if (entry.name === '.git') continue;
+    const srcPath = path.join(sourceRoot, entry.name);
+    const destPath = path.join(cacheDir, entry.name);
+    if (entry.isDirectory()) {
+      await fsPromises.cp(srcPath, destPath, { recursive: true });
+    } else {
+      await ensureDir(path.dirname(destPath));
+      await fsPromises.copyFile(srcPath, destPath);
+    }
+  }
 }
 
 async function getPreferredRemoteRef(cacheDir) {
@@ -196,6 +233,7 @@ function getAllFilesSync(dir, baseDir = dir) {
     const fullPath = path.join(dir, entry.name);
     const relPath = path.relative(baseDir, fullPath);
     if (entry.isDirectory()) {
+      if (entry.name === '.git' || entry.name === '.crules-git') continue;
       Object.assign(files, getAllFilesSync(fullPath, baseDir));
     } else {
       files[relPath] = fullPath;
@@ -216,6 +254,7 @@ async function getAllFiles(dir, baseDir = dir) {
     const relPath = path.relative(baseDir, fullPath);
 
     if (entry.isDirectory()) {
+      if (entry.name === '.git' || entry.name === '.crules-git') continue;
       const subFiles = await getAllFiles(fullPath, baseDir);
       Object.assign(files, subFiles);
     } else {
@@ -315,11 +354,12 @@ async function getGitDiff(cwd, filePath) {
  * Returns paths relative to source (e.g. "rules/foo.mdc").
  */
 async function getRemoteDiffPaths(cacheDir) {
+  const gitDir = getCacheGitDir(cacheDir);
   const sourcePath = getActiveConfig().sourcePath ?? '.cursor';
   const gitPath = sourcePath || '.';
 
   try {
-    await execAsync('git fetch origin', { cwd: cacheDir });
+    await execAsync('git fetch origin', { cwd: gitDir });
   } catch {
     return [];
   }
@@ -327,12 +367,12 @@ async function getRemoteDiffPaths(cacheDir) {
   let remoteRef = 'origin/HEAD';
   try {
     const { stdout: branch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
-      cwd: cacheDir
+      cwd: gitDir
     });
     const br = branch.trim();
     if (br && br !== 'HEAD') {
       try {
-        await execAsync(`git rev-parse --verify origin/${br}`, { cwd: cacheDir });
+        await execAsync(`git rev-parse --verify origin/${br}`, { cwd: gitDir });
         remoteRef = `origin/${br}`;
       } catch {
         /* no upstream branch */
@@ -344,7 +384,7 @@ async function getRemoteDiffPaths(cacheDir) {
 
   try {
     const { stdout } = await execAsync(`git diff --name-only HEAD ${remoteRef} -- "${gitPath}"`, {
-      cwd: cacheDir
+      cwd: gitDir
     });
     const lines = stdout.trim().split('\n').filter(Boolean);
     const prefix =
@@ -440,6 +480,7 @@ async function ensureGitIdentity(targetCwd, fallbackCwd = null) {
 
 module.exports = {
   getCacheDir,
+  getCacheGitDir,
   getCursorSourceDir,
   getProjectSpecificPattern,
   isProjectSpecificPath,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,6 +144,8 @@ async function ensureCache(verbose = false, options = {}) {
     }
   }
 
+  await ensureHiddenMetadataDir(gitDir);
+
   const sourceRoot = sourcePath && sourcePath !== '.' ? path.join(gitDir, sourcePath) : gitDir;
   if (!pathExists(sourceRoot)) {
     throw new Error(`Source directory '${sourcePath}' not found in repository`);
@@ -151,6 +153,14 @@ async function ensureCache(verbose = false, options = {}) {
 
   await hydrateAliasCacheFromSource(cacheDir, gitDir, sourceRoot);
   return getCursorSourceDir();
+}
+
+async function ensureHiddenMetadataDir(gitDir) {
+  if (process.platform !== 'win32') return;
+  try {
+    await execAsync(`attrib +h "${gitDir}"`);
+  } catch {
+  }
 }
 
 async function hydrateAliasCacheFromSource(cacheDir, gitDir, sourceRoot) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,11 +117,17 @@ async function ensureCache(verbose = false, options = {}) {
   } else if (!skipPull) {
     if (verbose) console.log('🔄 Updating Cursor Rules repository...');
     try {
-      await execAsync('git pull', { cwd: cacheDir });
+      await execAsync('git fetch origin', { cwd: cacheDir });
+      const remoteRef = await getPreferredRemoteRef(cacheDir);
+      await execAsync(`git reset --hard ${remoteRef}`, { cwd: cacheDir });
+      await execAsync('git clean -fd', { cwd: cacheDir });
     } catch (error) {
       if (verbose) console.log('⚠️  Pull failed, trying fetch...');
       try {
         await execAsync('git fetch origin', { cwd: cacheDir });
+        const remoteRef = await getPreferredRemoteRef(cacheDir);
+        await execAsync(`git reset --hard ${remoteRef}`, { cwd: cacheDir });
+        await execAsync('git clean -fd', { cwd: cacheDir });
       } catch (fetchError) {
         throw new Error(
           `Failed to update repository: ${error.message}\nMake sure you have network access and git is properly configured.`
@@ -130,6 +136,27 @@ async function ensureCache(verbose = false, options = {}) {
     }
   }
   return getCursorSourceDir();
+}
+
+async function getPreferredRemoteRef(cacheDir) {
+  let remoteRef = 'origin/HEAD';
+  try {
+    const { stdout: branch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      cwd: cacheDir
+    });
+    const br = branch.trim();
+    if (br && br !== 'HEAD') {
+      try {
+        await execAsync(`git rev-parse --verify origin/${br}`, { cwd: cacheDir });
+        remoteRef = `origin/${br}`;
+      } catch {
+        // keep origin/HEAD fallback
+      }
+    }
+  } catch {
+    // keep origin/HEAD fallback
+  }
+  return remoteRef;
 }
 
 function getProjectSpecificFiles(targetDir) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,8 +159,7 @@ async function ensureHiddenMetadataDir(gitDir) {
   if (process.platform !== 'win32') return;
   try {
     await execAsync(`attrib +h "${gitDir}"`);
-  } catch {
-  }
+  } catch {}
 }
 
 async function hydrateAliasCacheFromSource(cacheDir, gitDir, sourceRoot) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crules-cli",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "CLI to pull and push plugin configs (open plugin standard: rules, skills, agents, hooks) from your own repository",
   "main": "bin/crules.js",
   "bin": {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -45,7 +45,7 @@ const utils = require('../lib/utils.js');
 const { getStatus } = require('../lib/commands/status.js');
 
 const projCursor = path.join(tmpProject, '.cursor');
-const cacheCursor = path.join(tmpCache, '.cursor');
+const cacheCursor = tmpCache;
 
 function wipeCursorTrees() {
   for (const root of [projCursor, cacheCursor]) {

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -126,4 +126,19 @@ describe('syncCommand (pull)', () => {
     await syncCommand({ quiet: true, force: true });
     expect(fs.existsSync(path.join(destRoot, 'rules', 'a.mdc'))).toBe(true);
   });
+
+  it('never copies hidden .crules-git metadata into project target', async () => {
+    const srcRoot = path.join(tmpProject, 'cache-src', '.cursor');
+    const destRoot = path.join(tmpProject, '.cursor');
+    fs.mkdirSync(path.join(srcRoot, '.crules-git'), { recursive: true });
+    fs.writeFileSync(path.join(srcRoot, '.crules-git', 'HEAD'), 'ref: refs/heads/main\n', 'utf8');
+    fs.mkdirSync(path.join(srcRoot, 'rules'), { recursive: true });
+    fs.writeFileSync(path.join(srcRoot, 'rules', 'a.mdc'), 'x', 'utf8');
+    fs.mkdirSync(destRoot, { recursive: true });
+
+    await syncCommand({ quiet: true, force: true });
+
+    expect(fs.existsSync(path.join(destRoot, 'rules', 'a.mdc'))).toBe(true);
+    expect(fs.existsSync(path.join(destRoot, '.crules-git'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Release v1.2.6

This PR prepares the package for version 1.2.6 release.

### Changes
- Changed: cache model now mirrors selected `sourcePath` contents into each alias `cacheDir`, with hidden `.crules-git` metadata per alias.
- Changed: push/status/sync flows now use hidden git metadata while keeping cache mirror contents project-focused.
- Changed: README cache structure docs now include nested `skills/.../SKILL.md` examples aligned with the new model.
- Fixed: pull/sync excludes `.crules-git` from project copies with regression coverage for metadata leakage prevention.
- Fixed: Windows now applies hidden attribute to `.crules-git` as best-effort behavior.